### PR TITLE
Add review entity and routes with rating summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ A comprehensive headless e-commerce API built with Node.js, Express, TypeScript,
 ## API Endpoints
 
 ### Products
-- `GET /api/products` - List products with filtering and pagination
-- `GET /api/products/:id` - Get single product with variants
+- `GET /api/products` - List products with filtering, pagination, and review summary
+- `GET /api/products/:id` - Get single product with variants and review summary
 - `POST /api/products` - Create new product
 - `PUT /api/products/:id` - Update product
 - `DELETE /api/products/:id` - Delete product
@@ -91,6 +91,13 @@ A comprehensive headless e-commerce API built with Node.js, Express, TypeScript,
 - `GET /api/orders/:id` - Get single order
 - `POST /api/orders` - Create order
 - `PUT /api/orders/:id` - Update order
+
+### Reviews
+- `GET /api/reviews` - List reviews with pagination
+- `GET /api/reviews/:id` - Get single review
+- `POST /api/reviews` - Create review
+- `PUT /api/reviews/:id` - Update review
+- `DELETE /api/reviews/:id` - Delete review
 
 ### Additional endpoints for payments, promotions, campaigns, inventory, and product options.
 

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -30,6 +30,7 @@ import { Shipment } from "./entities/Shipment";
 import { Role } from "./entities/Role";
 import { ApiKey } from "./entities/ApiKey";
 import { OAuthAccount } from "./entities/OAuthAccount";
+import { Review } from "./entities/Review";
 
 dotenv.config();
 
@@ -70,6 +71,7 @@ export const AppDataSource = new DataSource({
     Role,
     ApiKey,
     OAuthAccount,
+    Review,
   ],
   migrations: ["src/migrations/*.ts"],
   subscribers: ["src/subscribers/*.ts"],

--- a/src/entities/Product.ts
+++ b/src/entities/Product.ts
@@ -108,6 +108,12 @@ export class Product {
   @IsBoolean()
   trackInventory: boolean;
 
+  @Column({ type: "decimal", precision: 3, scale: 2, default: 0 })
+  averageRating: number;
+
+  @Column({ default: 0 })
+  reviewCount: number;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/entities/Review.ts
+++ b/src/entities/Review.ts
@@ -1,0 +1,59 @@
+import {
+  Entity,
+  ObjectIdColumn,
+  ObjectId,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  BeforeInsert,
+} from "typeorm";
+import { IsNotEmpty, IsUUID, IsInt, Min, Max, IsOptional } from "class-validator";
+import { v4 as uuidv4 } from "uuid";
+import { ReviewStatus } from "../enums/review_status";
+
+@Entity("reviews")
+export class Review {
+  @ObjectIdColumn()
+  _id: ObjectId;
+
+  @Column()
+  id: string;
+
+  @Column()
+  @IsNotEmpty()
+  productId: string;
+
+  @Column()
+  @IsNotEmpty()
+  customerId: string;
+
+  @Column()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating: number;
+
+  @Column({ nullable: true })
+  @IsOptional()
+  comment?: string;
+
+  @Column({
+    type: "enum",
+    enum: ReviewStatus,
+    default: ReviewStatus.PENDING,
+  })
+  status: ReviewStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @BeforeInsert()
+  generateId() {
+    if (!this.id) {
+      this.id = uuidv4();
+    }
+  }
+}

--- a/src/enums/review_status.ts
+++ b/src/enums/review_status.ts
@@ -1,0 +1,5 @@
+export enum ReviewStatus {
+  PENDING = "pending",
+  APPROVED = "approved",
+  REJECTED = "rejected",
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import savedPaymentMethodRoutes from "./routes/saved-payment-methods";
 import webhookRoutes from "./routes/webhooks";
 import refundRoutes from "./routes/refunds";
 import analyticsRoutes from "./routes/analytics";
+import reviewRoutes from "./routes/reviews";
 
 // Import middleware
 import { errorHandler } from "./middleware/errorHandler";
@@ -108,6 +109,7 @@ app.use("/api", savedPaymentMethodRoutes); // This includes /customers/:id/payme
 app.use("/api/webhooks", webhookRoutes);
 app.use("/api/refunds", refundRoutes);
 app.use("/api/analytics", analyticsRoutes);
+app.use("/api/reviews", reviewRoutes);
 
 // Authentication & Authorization Routes
 app.use("/api/admin/auth", adminAuthRoutes);

--- a/src/routes/products.ts
+++ b/src/routes/products.ts
@@ -149,7 +149,13 @@ router.get("/", async (req: Request, res: Response) => {
     ]);
 
     res.json({
-      products,
+      products: products.map((p) => ({
+        ...p,
+        reviewSummary: {
+          averageRating: p.averageRating,
+          reviewCount: p.reviewCount,
+        },
+      })),
       pagination: {
         page: Number(page),
         limit: Number(limit),
@@ -177,7 +183,13 @@ router.get("/:id", async (req: Request, res: Response) => {
       return res.status(404).json({ error: "Product not found" });
     }
 
-    res.json(product);
+    res.json({
+      ...product,
+      reviewSummary: {
+        averageRating: product.averageRating,
+        reviewCount: product.reviewCount,
+      },
+    });
   } catch (error) {
     console.error("Error fetching product:", error);
     res.status(500).json({ error: "Failed to fetch product" });

--- a/src/routes/reviews.ts
+++ b/src/routes/reviews.ts
@@ -1,0 +1,164 @@
+import { Router, Request, Response } from "express";
+import { AppDataSource } from "../data-source";
+import { Review } from "../entities/Review";
+import { Product } from "../entities/Product";
+import { ReviewStatus } from "../enums/review_status";
+import { validate } from "class-validator";
+
+const router = Router();
+
+async function updateProductRating(productId: string) {
+  const reviewRepository = AppDataSource.getRepository(Review);
+  const productRepository = AppDataSource.getRepository(Product);
+
+  const reviews = await reviewRepository.find({
+    where: { productId, status: ReviewStatus.APPROVED },
+  });
+
+  const reviewCount = reviews.length;
+  const averageRating =
+    reviewCount > 0
+      ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviewCount
+      : 0;
+
+  await productRepository.update(
+    { id: productId },
+    { averageRating, reviewCount }
+  );
+}
+
+// List reviews with pagination
+router.get("/", async (req: Request, res: Response) => {
+  try {
+    const {
+      page = 1,
+      limit = 20,
+      productId,
+      customerId,
+      status,
+    } = req.query;
+
+    const reviewRepository = AppDataSource.getRepository(Review);
+    const query: any = {};
+
+    if (productId) query.productId = productId;
+    if (customerId) query.customerId = customerId;
+    if (status) query.status = status;
+
+    const skip = (Number(page) - 1) * Number(limit);
+
+    const [reviews, total] = await Promise.all([
+      reviewRepository.find({
+        where: query,
+        skip,
+        take: Number(limit),
+        order: { createdAt: "DESC" },
+      }),
+      reviewRepository.count({ where: query }),
+    ]);
+
+    res.json({
+      reviews,
+      pagination: {
+        page: Number(page),
+        limit: Number(limit),
+        total,
+        pages: Math.ceil(total / Number(limit)),
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching reviews:", error);
+    res.status(500).json({ error: "Failed to fetch reviews" });
+  }
+});
+
+// Get single review
+router.get("/:id", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const reviewRepository = AppDataSource.getRepository(Review);
+
+    const review = await reviewRepository.findOne({ where: { id } });
+
+    if (!review) {
+      return res.status(404).json({ error: "Review not found" });
+    }
+
+    res.json(review);
+  } catch (error) {
+    console.error("Error fetching review:", error);
+    res.status(500).json({ error: "Failed to fetch review" });
+  }
+});
+
+// Create review
+router.post("/", async (req: Request, res: Response) => {
+  try {
+    const reviewRepository = AppDataSource.getRepository(Review);
+
+    const review = reviewRepository.create(req.body as Partial<Review>);
+
+    const errors = await validate(review);
+    if (errors.length > 0) {
+      return res.status(400).json({ errors });
+    }
+
+    const savedReview = await reviewRepository.save(review);
+    await updateProductRating(savedReview.productId);
+
+    res.status(201).json(savedReview);
+  } catch (error) {
+    console.error("Error creating review:", error);
+    res.status(500).json({ error: "Failed to create review" });
+  }
+});
+
+// Update review
+router.put("/:id", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const reviewRepository = AppDataSource.getRepository(Review);
+
+    const review = await reviewRepository.findOne({ where: { id } });
+    if (!review) {
+      return res.status(404).json({ error: "Review not found" });
+    }
+
+    Object.assign(review, req.body);
+    const errors = await validate(review);
+    if (errors.length > 0) {
+      return res.status(400).json({ errors });
+    }
+
+    const updatedReview = await reviewRepository.save(review);
+    await updateProductRating(updatedReview.productId);
+
+    res.json(updatedReview);
+  } catch (error) {
+    console.error("Error updating review:", error);
+    res.status(500).json({ error: "Failed to update review" });
+  }
+});
+
+// Delete review
+router.delete("/:id", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const reviewRepository = AppDataSource.getRepository(Review);
+
+    const review = await reviewRepository.findOne({ where: { id } });
+    if (!review) {
+      return res.status(404).json({ error: "Review not found" });
+    }
+
+    await reviewRepository.remove(review);
+    await updateProductRating(review.productId);
+
+    res.status(204).send();
+  } catch (error) {
+    console.error("Error deleting review:", error);
+    res.status(500).json({ error: "Failed to delete review" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add `Review` entity and CRUD endpoints
- store and expose product review summaries
- document review endpoints in README

## Testing
- `npm run build` *(fails: ProductOption type errors and auth util issues)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b35a0101fc83318f5a8312bea92b15