### PR TITLE
feat(paypal): add vault customer creation and webhook verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ MAX_FILE_SIZE=5242880
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
+
+# PayPal Configuration
+PAYPAL_CLIENT_ID=your_paypal_client_id
+PAYPAL_CLIENT_SECRET=your_paypal_client_secret
+PAYPAL_ENVIRONMENT=sandbox
+PAYPAL_WEBHOOK_ID=your_paypal_webhook_id

--- a/.env.payment-example
+++ b/.env.payment-example
@@ -8,7 +8,7 @@ STRIPE_WEBHOOK_SECRET=whsec_1234567890abcdef
 # PayPal Configuration  
 PAYPAL_CLIENT_ID=your_paypal_client_id
 PAYPAL_CLIENT_SECRET=your_paypal_client_secret
-PAYPAL_MODE=sandbox
+PAYPAL_ENVIRONMENT=sandbox
 PAYPAL_WEBHOOK_ID=your_paypal_webhook_id
 
 # JWT Configuration (if not already set)


### PR DESCRIPTION
## Summary
- integrate PayPal Vault API for customer creation
- verify PayPal webhooks against PayPal's verification endpoint
- document PayPal environment variables and webhook id

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Type 'ProductOption[]' is missing the following properties from type 'ProductOption': _id, id, name, position, and 9 more.)

------
https://chatgpt.com/codex/tasks/task_e_68b35a56440c83318460fd15efe516a1