### PR TITLE
feat: add transactional checkout endpoint

### DIFF
--- a/CHECKOUT_PROCESS.md
+++ b/CHECKOUT_PROCESS.md
@@ -1,0 +1,55 @@
+# Checkout Process
+
+The checkout flow converts a completed cart into an order and records payment in a single transaction.
+
+## Endpoint
+
+`POST /api/checkout`
+
+### Request Body
+
+```
+{
+  "cartId": "string",
+  "customer": {
+    "email": "test@example.com",
+    "billingAddress": { ... },
+    "shippingAddress": { ... }
+  },
+  "shippingMethod": {
+    "shippingOptionId": "opt_123",
+    "name": "Standard",
+    "price": 10
+  },
+  "payment": {
+    "paymentIntentId": "pi_123",
+    "paymentMethodId": "pm_123"
+  }
+}
+```
+
+## Flow
+
+1. Validate the cart and merge any customer or address information.
+2. Apply the selected shipping method and recalculate taxes and totals.
+3. Confirm the provided payment intent with the payment gateway.
+4. Create the order and payment records inside a database transaction.
+5. Return the newly created order or actionable validation errors.
+
+### Successful Response
+
+```
+{
+  "order": { /* order data */ }
+}
+```
+
+### Error Response
+
+```
+{
+  "errors": ["Cart not found"]
+}
+```
+
+This process ensures that validation, pricing calculations, payment confirmation, and order creation either complete together or are rolled back on failure.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ A comprehensive headless e-commerce API built with Node.js, Express, TypeScript,
 - **Payments**: Multiple payment methods and status tracking
 - **Order Status**: Comprehensive status tracking (pending, processing, shipped, delivered)
 
+### Checkout
+- **Checkout API**: `/api/checkout` endpoint validates carts, confirms payment intents, and creates orders in a single transaction
+
 ### Marketing & Promotions
 - **Promotions**: Flexible promotion system (percentage, fixed amount, free shipping)
 - **Campaigns**: Marketing campaign management with analytics

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import refundRoutes from "./routes/refunds";
 import analyticsRoutes from "./routes/analytics";
 import wishlistRoutes from "./routes/wishlists";
 import reviewRoutes from "./routes/reviews";
+import checkoutRoutes from "./routes/checkout";
 
 // Import middleware
 import { errorHandler } from "./middleware/errorHandler";
@@ -112,6 +113,7 @@ app.use("/api/shipping-rates", shippingRateRoutes);
 app.use("/api/fulfillment-centers", fulfillmentCenterRoutes);
 app.use("/api/shipping-providers", shippingProviderRoutes);
 app.use("/api/shipments", shipmentRoutes);
+app.use("/api/checkout", checkoutRoutes);
 
 // Payment Integration Routes
 app.use("/api/payment-intents", paymentIntentRoutes);

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -1,0 +1,35 @@
+import { Router, Request, Response } from "express";
+import { CartToOrderService } from "../utils/cartToOrderService";
+
+const router = Router();
+const service = new CartToOrderService();
+
+router.post("/", async (req: Request, res: Response) => {
+  const { cartId, customer, shippingMethod, payment } = req.body;
+
+  if (!cartId || !payment?.paymentIntentId) {
+    return res.status(400).json({
+      error: "cartId and payment.paymentIntentId are required",
+    });
+  }
+
+  try {
+    const result = await service.checkout({
+      cartId,
+      customer,
+      shippingMethod,
+      payment,
+    });
+
+    if ((result as any).errors) {
+      return res.status(400).json(result);
+    }
+
+    res.json(result);
+  } catch (error: any) {
+    console.error("Checkout error:", error);
+    res.status(500).json({ error: error.message || "Checkout failed" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add `/api/checkout` endpoint for converting carts to orders
- orchestrate cart validation, payment intent confirmation, and order creation in `CartToOrderService`
- document the end-to-end checkout process

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'nodemailer', i18n modules, and TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b35d8e27308331b8774b778e8b779e