### PR TITLE
feat(admin): add login and auth token handling

### DIFF
--- a/admin/src/http.ts
+++ b/admin/src/http.ts
@@ -1,0 +1,11 @@
+export function setupAuthFetch() {
+  const originalFetch = window.fetch
+  window.fetch = async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const token = localStorage.getItem('accessToken')
+    const headers = new Headers(init.headers || {})
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`)
+    }
+    return originalFetch(input, { ...init, headers })
+  }
+}

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -4,9 +4,12 @@ import App from './App.vue'
 import router from './router'
 import PrimeVue from 'primevue/config'
 import Aura from '@primeuix/themes/lara'
+import { setupAuthFetch } from './http'
 
 import 'primeicons/primeicons.css'
 import 'primeflex/primeflex.css'
+
+setupAuthFetch()
 
 const app = createApp(App)
 app.use(router)

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -3,6 +3,12 @@ import type { RouteRecordRaw } from 'vue-router'
 
 const routes: RouteRecordRaw[] = [
   {
+    path: '/login',
+    name: 'Login',
+    component: () => import('../views/Login.vue'),
+    meta: { requiresAuth: false }
+  },
+  {
     path: '/',
     redirect: '/products'
   },
@@ -104,6 +110,23 @@ const routes: RouteRecordRaw[] = [
 const router = createRouter({
   history: createWebHistory(),
   routes
+})
+
+router.beforeEach((to, from, next) => {
+  const token = localStorage.getItem('accessToken')
+  if (to.meta.requiresAuth === false) {
+    if (token && to.path === '/login') {
+      next('/')
+    } else {
+      next()
+    }
+  } else {
+    if (token) {
+      next()
+    } else {
+      next('/login')
+    }
+  }
 })
 
 export default router

--- a/admin/src/views/Login.vue
+++ b/admin/src/views/Login.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="login-container">
+    <h1>Admin Login</h1>
+    <form @submit.prevent="login">
+      <input v-model="email" type="email" placeholder="Email" required />
+      <input v-model="password" type="password" placeholder="Password" required />
+      <button type="submit">Login</button>
+      <p v-if="error" class="error">{{ error }}</p>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const email = ref('')
+const password = ref('')
+const error = ref('')
+const router = useRouter()
+
+async function login() {
+  error.value = ''
+  try {
+    const response = await fetch('/api/admin/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email.value, password: password.value })
+    })
+
+    if (!response.ok) {
+      const data = await response.json()
+      throw new Error(data.error || 'Login failed')
+    }
+
+    const data = await response.json()
+    localStorage.setItem('accessToken', data.tokens.accessToken)
+    localStorage.setItem('refreshToken', data.tokens.refreshToken)
+    router.push('/')
+  } catch (err: any) {
+    error.value = err.message
+  }
+}
+</script>
+
+<style scoped>
+.login-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 100px;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+  gap: 10px;
+}
+.error {
+  color: red;
+}
+</style>


### PR DESCRIPTION
## Summary
- add admin login view using backend `/api/admin/auth/login`
- secure tokens in localStorage and auto-append Authorization header
- guard routes and redirect unauthenticated users to login

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build --prefix admin` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b361b4b57883318a2846edefa10c0e