### PR TITLE
feat(admin): add typed http client

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:3000

--- a/admin/src/api/httpClient.ts
+++ b/admin/src/api/httpClient.ts
@@ -1,0 +1,42 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+
+type RequestConfig = RequestInit & { params?: Record<string, any> }
+
+function buildUrl(endpoint: string, params?: Record<string, any>): string {
+  const url = new URL(endpoint, API_BASE_URL)
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      url.searchParams.append(key, String(value))
+    })
+  }
+  return url.toString()
+}
+
+async function request<T>(endpoint: string, config: RequestConfig = {}): Promise<T> {
+  const { params, headers, ...init } = config
+  const url = buildUrl(endpoint, params)
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers
+    },
+    ...init
+  })
+  if (!response.ok) {
+    throw new Error(`HTTP error ${response.status}`)
+  }
+  return await response.json() as T
+}
+
+export const httpClient = {
+  get: <T>(endpoint: string, config?: Omit<RequestConfig, 'method' | 'body'>) =>
+    request<T>(endpoint, { ...config, method: 'GET' }),
+  post: <T, B = unknown>(endpoint: string, body: B, config?: Omit<RequestConfig, 'method'>) =>
+    request<T>(endpoint, { ...config, method: 'POST', body: JSON.stringify(body) }),
+  put: <T, B = unknown>(endpoint: string, body: B, config?: Omit<RequestConfig, 'method'>) =>
+    request<T>(endpoint, { ...config, method: 'PUT', body: JSON.stringify(body) }),
+  delete: <T>(endpoint: string, config?: Omit<RequestConfig, 'method' | 'body'>) =>
+    request<T>(endpoint, { ...config, method: 'DELETE' })
+}
+
+export default httpClient


### PR DESCRIPTION
## Summary
- add fetch-based httpClient with typed CRUD helpers
- configure API base URL via Vite env variable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix admin test` *(fails: Missing script "test")*
- `npm --prefix admin run build` *(fails: ProductView.vue unused imports, ProductCreateModal.vue unused props)*

------
https://chatgpt.com/codex/tasks/task_e_68b361b830948331b111ead601e87db8