### PR TITLE
feat(admin): add webhook events list

### DIFF
--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -102,7 +102,8 @@ const routes: RouteRecordRaw[] = [
       { path: 'shipping-rates', name: 'ShippingRates', component: () => import('../views/settings/ShippingRatesList.vue') },
       { path: 'shipping-zones', name: 'ShippingZones', component: () => import('../views/settings/ShippingZonesList.vue') },
       { path: 'tax-regions', name: 'TaxRegions', component: () => import('../views/settings/TaxRegionsList.vue') },
-      { path: 'users', name: 'Users', component: () => import('../views/settings/UsersList.vue') }
+      { path: 'users', name: 'Users', component: () => import('../views/settings/UsersList.vue') },
+      { path: 'webhooks', name: 'Webhooks', component: () => import('../views/settings/WebhooksList.vue') }
     ]
   }
 ]

--- a/admin/src/views/Settings.vue
+++ b/admin/src/views/Settings.vue
@@ -1,6 +1,21 @@
 <template>
   <div>
     <h1>Settings</h1>
+    <nav class="settings-nav">
+      <router-link to="/settings/payments">Payments</router-link>
+      <router-link to="/settings/payment-intents">Payment Intents</router-link>
+      <router-link to="/settings/refunds">Refunds</router-link>
+      <router-link to="/settings/roles">Roles</router-link>
+      <router-link to="/settings/sales-channels">Sales Channels</router-link>
+      <router-link to="/settings/saved-payment-methods">Saved Payment Methods</router-link>
+      <router-link to="/settings/shipments">Shipments</router-link>
+      <router-link to="/settings/shipping-providers">Shipping Providers</router-link>
+      <router-link to="/settings/shipping-rates">Shipping Rates</router-link>
+      <router-link to="/settings/shipping-zones">Shipping Zones</router-link>
+      <router-link to="/settings/tax-regions">Tax Regions</router-link>
+      <router-link to="/settings/users">Users</router-link>
+      <router-link to="/settings/webhooks">Webhooks</router-link>
+    </nav>
     <router-view />
   </div>
 </template>
@@ -8,3 +23,24 @@
 <script setup lang="ts">
 // Settings parent view
 </script>
+
+<style scoped>
+.settings-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.settings-nav a {
+  padding: 4px 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.settings-nav a.router-link-active {
+  background-color: #f3f4f6;
+}
+</style>

--- a/admin/src/views/settings/WebhooksList.vue
+++ b/admin/src/views/settings/WebhooksList.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="webhooks-list">
+    <h1>Webhook Events</h1>
+
+    <div v-if="loading" class="state">Loading...</div>
+    <div v-else-if="error" class="state error">{{ error }}</div>
+    <table v-else class="events-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Source</th>
+          <th>Type</th>
+          <th>Status</th>
+          <th>Created</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="event in events" :key="event.id">
+          <td>{{ event.id }}</td>
+          <td>{{ event.source }}</td>
+          <td>{{ event.type }}</td>
+          <td>{{ event.status }}</td>
+          <td>{{ new Date(event.createdAt).toLocaleString() }}</td>
+          <td>
+            <button v-if="event.status === 'failed'" @click="retryEvent(event.id)">Retry</button>
+          </td>
+        </tr>
+        <tr v-if="events.length === 0">
+          <td colspan="6">No events found</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface WebhookEvent {
+  id: string
+  source: string
+  type: string
+  status: string
+  createdAt: string
+}
+
+const events = ref<WebhookEvent[]>([])
+const loading = ref(false)
+const error = ref('')
+
+const fetchEvents = async () => {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await fetch('/api/webhooks/events')
+    if (!res.ok) throw new Error('Failed to fetch webhook events')
+    const data = await res.json()
+    events.value = data.data ?? []
+  } catch (err: any) {
+    error.value = err.message || 'Error fetching webhook events'
+  } finally {
+    loading.value = false
+  }
+}
+
+const retryEvent = async (id: string) => {
+  if (!confirm('Retry this webhook event?')) return
+  try {
+    const res = await fetch(`/api/webhooks/events/${id}/retry`, { method: 'POST' })
+    if (!res.ok) throw new Error('Failed to retry webhook event')
+    await fetchEvents()
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+onMounted(fetchEvents)
+</script>
+
+<style scoped>
+.events-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.events-table th,
+.events-table td {
+  padding: 8px;
+  border: 1px solid #ddd;
+  text-align: left;
+}
+
+.state {
+  margin: 20px 0;
+}
+
+.state.error {
+  color: red;
+}
+</style>


### PR DESCRIPTION
## Summary
- show webhook events with retry action in settings
- add webhooks route and link from settings navigation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b36454e2208331a85576545cf206cf