### PR TITLE
feat: add customer wishlist view

### DIFF
--- a/admin/src/api/customers.ts
+++ b/admin/src/api/customers.ts
@@ -1,0 +1,25 @@
+import httpClient from './httpClient'
+
+export interface Wishlist {
+  id: string
+  customerId: string
+  productIds: string[]
+}
+
+interface WishlistResponse {
+  success: boolean
+  data: Wishlist
+}
+
+export function getCustomerWishlist(customerId: string) {
+  return httpClient.get<WishlistResponse>(`/customers/${customerId}/wishlist`)
+}
+
+export function addWishlistItem(customerId: string, productId: string) {
+  return httpClient.post<WishlistResponse, { productId: string }>(`/customers/${customerId}/wishlist`, { productId })
+}
+
+export function removeWishlistItem(customerId: string, productId: string) {
+  return httpClient.delete<WishlistResponse>(`/customers/${customerId}/wishlist/${productId}`)
+}
+

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -70,6 +70,16 @@ const routes: RouteRecordRaw[] = [
     ]
   },
   {
+    path: '/customers/:id',
+    name: 'CustomerDetail',
+    component: () => import('../views/customers/CustomerDetail.vue')
+  },
+  {
+    path: '/customers/:id/wishlist',
+    name: 'CustomerWishlist',
+    component: () => import('../views/customers/CustomerWishlist.vue')
+  },
+  {
     path: '/promotions',
     name: 'Promotions',
     component: () => import('../views/PromotionsList.vue'),

--- a/admin/src/views/customers/CustomerDetail.vue
+++ b/admin/src/views/customers/CustomerDetail.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <h1>Customer Detail</h1>
+    <RouterLink :to="`/customers/${customerId}/wishlist`">View Wishlist</RouterLink>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRoute, RouterLink } from 'vue-router'
+
+const route = useRoute()
+const customerId = route.params.id as string
+</script>

--- a/admin/src/views/customers/CustomerWishlist.vue
+++ b/admin/src/views/customers/CustomerWishlist.vue
@@ -1,0 +1,45 @@
+<template>
+  <div>
+    <h1>Customer Wishlist</h1>
+    <div>
+      <input v-model="newProductId" placeholder="Product ID" />
+      <button @click="addItem">Add</button>
+    </div>
+    <ul>
+      <li v-for="id in wishlist.productIds" :key="id">
+        {{ id }}
+        <button @click="removeItem(id)">Remove</button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { getCustomerWishlist, addWishlistItem, removeWishlistItem, Wishlist } from '../../api/customers'
+
+const route = useRoute()
+const customerId = route.params.id as string
+const wishlist = ref<Wishlist>({ id: '', customerId, productIds: [] })
+const newProductId = ref('')
+
+async function fetchWishlist() {
+  const response = await getCustomerWishlist(customerId)
+  wishlist.value = response.data
+}
+
+async function addItem() {
+  if (!newProductId.value) return
+  await addWishlistItem(customerId, newProductId.value)
+  newProductId.value = ''
+  await fetchWishlist()
+}
+
+async function removeItem(id: string) {
+  await removeWishlistItem(customerId, id)
+  await fetchWishlist()
+}
+
+onMounted(fetchWishlist)
+</script>


### PR DESCRIPTION
## Summary
- add customer wishlist API helpers
- create customer detail and wishlist views
- wire wishlist routes into router

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3645634cc83318c26dd1b47251183