### PR TITLE
feat: add analytics dashboard

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,6 +11,7 @@
         "@primeuix/styles": "^1.2.3",
         "@primeuix/themes": "^1.2.3",
         "@tabler/icons-vue": "^3.34.1",
+        "chart.js": "^4.5.0",
         "primeflex": "^4.0.0",
         "primeicons": "^7.0.0",
         "primevue": "^4.3.7",
@@ -517,6 +518,12 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
       "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "license": "MIT"
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
     "node_modules/@primeuix/styled": {
@@ -1136,6 +1143,18 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/csstype": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -12,6 +12,7 @@
     "@primeuix/styles": "^1.2.3",
     "@primeuix/themes": "^1.2.3",
     "@tabler/icons-vue": "^3.34.1",
+    "chart.js": "^4.5.0",
     "primeflex": "^4.0.0",
     "primeicons": "^7.0.0",
     "primevue": "^4.3.7",

--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -9,7 +9,8 @@ import {
   IconChevronRight,
   IconSearch,
   IconStack,
-  IconBell
+  IconBell,
+  IconChartBar
 } from '@tabler/icons-vue'
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
@@ -38,6 +39,7 @@ const routeDescriptions: Record<string, string> = {
   'Customers': 'Manage your customers',
   'Promotions': 'Create and manage promotions',
   'PriceLists': 'Manage your price lists',
+  'Analytics': 'View store analytics',
   'Settings': 'Configure your store settings'
 }
 
@@ -75,7 +77,13 @@ const getPageDescription = computed(() => {
               <span class="keyboard-shortcut">⌘K</span>
             </router-link>
           </div>
-          
+
+          <!-- Analytics -->
+          <router-link to="/analytics" class="menu-item">
+            <IconChartBar :size="18" />
+            <span>Analytics</span>
+          </router-link>
+
           <!-- Orders -->
           <router-link to="/orders" class="menu-item">
             <IconShoppingCart :size="18" />

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -13,6 +13,11 @@ const routes: RouteRecordRaw[] = [
     redirect: '/products'
   },
   {
+    path: '/analytics',
+    name: 'Analytics',
+    component: () => import('../views/AnalyticsDashboard.vue'),
+  },
+  {
     path: '/products',
     name: 'Products',
     component: () => import('../views/products/ProductsList.vue'),
@@ -112,7 +117,7 @@ const router = createRouter({
   routes
 })
 
-router.beforeEach((to, from, next) => {
+router.beforeEach((to, _from, next) => {
   const token = localStorage.getItem('accessToken')
   if (to.meta.requiresAuth === false) {
     if (token && to.path === '/login') {

--- a/admin/src/views/AnalyticsDashboard.vue
+++ b/admin/src/views/AnalyticsDashboard.vue
@@ -1,0 +1,238 @@
+<template>
+  <div class="analytics-dashboard">
+    <h1>Analytics Dashboard</h1>
+
+    <div v-if="loading" class="state">Loading...</div>
+    <div v-else-if="error" class="state error">{{ error }}</div>
+    <div v-else>
+      <!-- Summary Stats -->
+      <div class="stats">
+        <div class="stat-card">
+          <h3>Total Products</h3>
+          <p>{{ dashboard.totalProducts }}</p>
+        </div>
+        <div class="stat-card">
+          <h3>Total Orders</h3>
+          <p>{{ dashboard.totalOrders }}</p>
+        </div>
+        <div class="stat-card">
+          <h3>Total Customers</h3>
+          <p>{{ dashboard.totalCustomers }}</p>
+        </div>
+        <div class="stat-card">
+          <h3>Total Revenue</h3>
+          <p>{{ formatCurrency(dashboard.totalRevenue) }}</p>
+        </div>
+      </div>
+
+      <!-- Sales Chart -->
+      <div class="section">
+        <h2>Sales (Last 30 Days)</h2>
+        <Chart
+          v-if="sales.length"
+          type="line"
+          :data="chartData"
+          :options="chartOptions"
+        />
+        <div v-else>No sales data available</div>
+      </div>
+
+      <!-- Top Products -->
+      <div class="section">
+        <h2>Top Products</h2>
+        <table class="top-products-table">
+          <thead>
+            <tr>
+              <th>Product</th>
+              <th>Sales</th>
+              <th>Revenue</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="p in topProducts" :key="p.id">
+              <td>{{ p.title }}</td>
+              <td>{{ p.sales }}</td>
+              <td>{{ formatCurrency(p.revenue) }}</td>
+            </tr>
+            <tr v-if="topProducts.length === 0">
+              <td colspan="3">No product data</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Customer Stats -->
+      <div class="section">
+        <h2>Customers</h2>
+        <ul>
+          <li>New Customers: {{ customers.newCustomers }}</li>
+          <li>Returning Customers: {{ customers.returningCustomers }}</li>
+          <li>Average Order Value: {{ formatCurrency(customers.averageOrderValue) }}</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import Chart from 'primevue/chart'
+
+interface DashboardStats {
+  totalProducts: number
+  totalOrders: number
+  totalCustomers: number
+  totalRevenue: number
+}
+
+interface SalesEntry {
+  date: string
+  sales: number
+  orders: number
+}
+
+interface TopProduct {
+  id: string
+  title: string
+  sales: number
+  revenue: number
+}
+
+interface CustomerStats {
+  newCustomers: number
+  returningCustomers: number
+  averageOrderValue: number
+}
+
+const dashboard = ref<DashboardStats>({
+  totalProducts: 0,
+  totalOrders: 0,
+  totalCustomers: 0,
+  totalRevenue: 0
+})
+const sales = ref<SalesEntry[]>([])
+const topProducts = ref<TopProduct[]>([])
+const customers = ref<CustomerStats>({
+  newCustomers: 0,
+  returningCustomers: 0,
+  averageOrderValue: 0
+})
+
+const loading = ref(true)
+const error = ref('')
+
+onMounted(() => {
+  fetchAll()
+})
+
+async function fetchAll() {
+  try {
+    await Promise.all([
+      fetchDashboard(),
+      fetchSales(),
+      fetchTopProducts(),
+      fetchCustomers()
+    ])
+  } catch (err: any) {
+    error.value = err.message || 'Failed to load analytics'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function fetchDashboard() {
+  const res = await fetch('/api/analytics/dashboard')
+  if (!res.ok) throw new Error('Failed to fetch dashboard')
+  dashboard.value = await res.json()
+}
+
+async function fetchSales() {
+  const res = await fetch('/api/analytics/sales')
+  if (!res.ok) throw new Error('Failed to fetch sales data')
+  const data = await res.json()
+  sales.value = data.data || []
+}
+
+async function fetchTopProducts() {
+  const res = await fetch('/api/analytics/top-products')
+  if (!res.ok) throw new Error('Failed to fetch top products')
+  topProducts.value = await res.json()
+}
+
+async function fetchCustomers() {
+  const res = await fetch('/api/analytics/customers')
+  if (!res.ok) throw new Error('Failed to fetch customer stats')
+  customers.value = await res.json()
+}
+
+const chartData = computed(() => ({
+  labels: sales.value.map(s => s.date),
+  datasets: [
+    {
+      label: 'Sales',
+      data: sales.value.map(s => s.sales),
+      fill: false,
+      borderColor: '#42A5F5',
+      tension: 0.4
+    }
+  ]
+}))
+
+const chartOptions = {
+  responsive: true,
+  plugins: {
+    legend: {
+      display: false
+    }
+  }
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(value)
+}
+</script>
+
+<style scoped>
+.analytics-dashboard {
+  padding: 1rem;
+}
+
+.stats {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.stat-card {
+  flex: 1;
+  background: #fff;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  text-align: center;
+}
+
+.section {
+  margin-top: 2rem;
+}
+
+.top-products-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.top-products-table th,
+.top-products-table td {
+  padding: 8px;
+  border: 1px solid #ddd;
+  text-align: left;
+}
+
+.state {
+  margin: 20px 0;
+}
+
+.state.error {
+  color: red;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add analytics dashboard with sales chart and stats
- wire up `/analytics` route and sidebar link
- include Chart.js for visualizations

## Testing
- `npm test`
- `npm run build` (fails: ProductView.vue props unused)


------
https://chatgpt.com/codex/tasks/task_e_68b364570c7483319e0484a876571f90