### PR TITLE
Add admin views for order issue workflows

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -35,6 +35,9 @@ const routeDescriptions: Record<string, string> = {
   'Products': 'Manage your inventory items',
   'Inventory': 'Manage your inventory items',
   'Orders': 'Manage customer orders',
+  'OrderClaims': 'Manage order claims',
+  'OrderExchanges': 'Manage order exchanges',
+  'OrderReturns': 'Manage order returns',
   'Customers': 'Manage your customers',
   'Promotions': 'Create and manage promotions',
   'PriceLists': 'Manage your price lists',
@@ -76,11 +79,36 @@ const getPageDescription = computed(() => {
             </router-link>
           </div>
           
-          <!-- Orders -->
-          <router-link to="/orders" class="menu-item">
-            <IconShoppingCart :size="18" />
-            <span>Orders</span>
-          </router-link>
+          <!-- Orders Menu -->
+          <div class="menu-group">
+            <button
+              @click="toggleMenu('orders')"
+              class="menu-item menu-group-toggle"
+              :class="{ 'expanded': isMenuExpanded('orders') }"
+            >
+              <IconShoppingCart :size="18" />
+              <span>Orders</span>
+              <IconChevronRight
+                :size="16"
+                class="chevron"
+                :class="{ 'rotated': isMenuExpanded('orders') }"
+              />
+            </button>
+            <div v-show="isMenuExpanded('orders')" class="sub-menu">
+              <router-link to="/orders" class="sub-menu-item">
+                <span>All Orders</span>
+              </router-link>
+              <router-link to="/orders/claims" class="sub-menu-item">
+                <span>Claims</span>
+              </router-link>
+              <router-link to="/orders/exchanges" class="sub-menu-item">
+                <span>Exchanges</span>
+              </router-link>
+              <router-link to="/orders/returns" class="sub-menu-item">
+                <span>Returns</span>
+              </router-link>
+            </div>
+          </div>
           
           <!-- Products Menu -->
           <div class="menu-group">

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -58,6 +58,21 @@ const routes: RouteRecordRaw[] = [
     component: () => import('../views/OrdersList.vue')
   },
   {
+    path: '/orders/claims',
+    name: 'OrderClaims',
+    component: () => import('../views/orders/ClaimsList.vue')
+  },
+  {
+    path: '/orders/exchanges',
+    name: 'OrderExchanges',
+    component: () => import('../views/orders/ExchangesList.vue')
+  },
+  {
+    path: '/orders/returns',
+    name: 'OrderReturns',
+    component: () => import('../views/orders/ReturnsList.vue')
+  },
+  {
     path: '/customers',
     name: 'Customers',
     component: () => import('../views/CustomersList.vue'),

--- a/admin/src/views/orders/ExchangesList.vue
+++ b/admin/src/views/orders/ExchangesList.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="exchanges-list">
+    <h1>Order Exchanges</h1>
+
+    <div v-if="loading" class="state">Loading...</div>
+    <div v-else-if="error" class="state error">{{ error }}</div>
+    <table v-else class="exchanges-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Order ID</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="ex in exchanges" :key="ex.id">
+          <td>{{ ex.id }}</td>
+          <td>{{ ex.orderId }}</td>
+          <td>{{ ex.status }}</td>
+          <td>
+            <select v-model="statusUpdates[ex.id]">
+              <option disabled value="">Select</option>
+              <option v-for="s in statusOptions" :key="s" :value="s">{{ s }}</option>
+            </select>
+            <button @click="updateStatus(ex.id)">Update</button>
+          </td>
+        </tr>
+        <tr v-if="exchanges.length === 0">
+          <td colspan="4">No exchanges found</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Create Exchange</h2>
+    <div class="create-form">
+      <input v-model="newExchange.orderId" placeholder="Order ID" />
+      <input v-model="newExchange.customerId" placeholder="Customer ID" />
+      <input v-model="newExchange.reason" placeholder="Reason" />
+      <textarea v-model="newExchange.returnItems" placeholder='Return items JSON'></textarea>
+      <textarea v-model="newExchange.exchangeItems" placeholder='Exchange items JSON'></textarea>
+      <input v-model="newExchange.customerNote" placeholder="Customer note" />
+      <textarea v-model="newExchange.shippingAddress" placeholder='Shipping address JSON'></textarea>
+      <button @click="createExchange">Create</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface Exchange {
+  id: string
+  orderId: string
+  customerId: string
+  status: string
+}
+
+const exchanges = ref<Exchange[]>([])
+const loading = ref(false)
+const error = ref('')
+
+const statusOptions = ['requested','approved','rejected','in_transit','received','processed','completed','cancelled']
+const statusUpdates = ref<Record<string, string>>({})
+
+const newExchange = ref({ orderId:'', customerId:'', reason:'', returnItems:'[]', exchangeItems:'[]', customerNote:'', shippingAddress:'{}' })
+
+onMounted(() => {
+  fetchExchanges()
+})
+
+async function fetchExchanges() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await fetch('/api/order-exchanges')
+    if (!res.ok) throw new Error('Failed to fetch exchanges')
+    const data = await res.json()
+    exchanges.value = data.exchanges ?? []
+  } catch (err: any) {
+    error.value = err.message || 'Error fetching exchanges'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function createExchange() {
+  try {
+    const body = {
+      orderId: newExchange.value.orderId,
+      customerId: newExchange.value.customerId,
+      reason: newExchange.value.reason,
+      customerNote: newExchange.value.customerNote,
+      returnItems: JSON.parse(newExchange.value.returnItems || '[]'),
+      exchangeItems: JSON.parse(newExchange.value.exchangeItems || '[]'),
+      shippingAddress: JSON.parse(newExchange.value.shippingAddress || '{}')
+    }
+    const res = await fetch('/api/order-exchanges', {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify(body)
+    })
+    if (!res.ok) throw new Error('Failed to create exchange')
+    await res.json()
+    newExchange.value = { orderId:'', customerId:'', reason:'', returnItems:'[]', exchangeItems:'[]', customerNote:'', shippingAddress:'{}' }
+    fetchExchanges()
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+async function updateStatus(id: string) {
+  const status = statusUpdates.value[id]
+  if (!status) return
+  try {
+    const res = await fetch(`/api/order-exchanges/${id}/status`, {
+      method:'PATCH',
+      headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify({ status })
+    })
+    if (!res.ok) throw new Error('Failed to update status')
+    await res.json()
+    fetchExchanges()
+  } catch (err) {
+    console.error(err)
+  }
+}
+</script>
+
+<style scoped>
+.exchanges-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.exchanges-table th,
+.exchanges-table td {
+  padding: 8px;
+  border: 1px solid #ddd;
+  text-align: left;
+}
+
+.state {
+  margin: 20px 0;
+}
+
+.state.error {
+  color: red;
+}
+
+.create-form {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.create-form input,
+.create-form textarea {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+}
+</style>

--- a/admin/src/views/orders/ReturnsList.vue
+++ b/admin/src/views/orders/ReturnsList.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="returns-list">
+    <h1>Order Returns</h1>
+
+    <div v-if="loading" class="state">Loading...</div>
+    <div v-else-if="error" class="state error">{{ error }}</div>
+    <table v-else class="returns-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Order ID</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="ret in returns" :key="ret.id">
+          <td>{{ ret.id }}</td>
+          <td>{{ ret.orderId }}</td>
+          <td>{{ ret.status }}</td>
+          <td>
+            <select v-model="statusUpdates[ret.id]">
+              <option disabled value="">Select</option>
+              <option v-for="s in statusOptions" :key="s" :value="s">{{ s }}</option>
+            </select>
+            <button @click="updateStatus(ret.id)">Update</button>
+          </td>
+        </tr>
+        <tr v-if="returns.length === 0">
+          <td colspan="4">No returns found</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Create Return</h2>
+    <div class="create-form">
+      <input v-model="newReturn.orderId" placeholder="Order ID" />
+      <input v-model="newReturn.customerId" placeholder="Customer ID" />
+      <input v-model="newReturn.reason" placeholder="Reason" />
+      <textarea v-model="newReturn.items" placeholder='Items JSON'></textarea>
+      <input v-model="newReturn.customerNote" placeholder="Customer note" />
+      <input v-model.number="newReturn.refundAmount" type="number" placeholder="Refund amount" />
+      <input v-model="newReturn.currency" placeholder="Currency" />
+      <button @click="createReturn">Create</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface OrderReturn {
+  id: string
+  orderId: string
+  customerId: string
+  status: string
+}
+
+const returns = ref<OrderReturn[]>([])
+const loading = ref(false)
+const error = ref('')
+
+const statusOptions = ['requested','approved','rejected','in_transit','received','processed','refunded','cancelled']
+const statusUpdates = ref<Record<string, string>>({})
+
+const newReturn = ref({ orderId:'', customerId:'', reason:'', items:'[]', customerNote:'', refundAmount:0, currency:'' })
+
+onMounted(() => {
+  fetchReturns()
+})
+
+async function fetchReturns() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await fetch('/api/order-returns')
+    if (!res.ok) throw new Error('Failed to fetch returns')
+    const data = await res.json()
+    returns.value = data.returns ?? []
+  } catch (err: any) {
+    error.value = err.message || 'Error fetching returns'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function createReturn() {
+  try {
+    const body = {
+      orderId: newReturn.value.orderId,
+      customerId: newReturn.value.customerId,
+      reason: newReturn.value.reason,
+      customerNote: newReturn.value.customerNote,
+      refundAmount: newReturn.value.refundAmount,
+      currency: newReturn.value.currency,
+      items: JSON.parse(newReturn.value.items || '[]')
+    }
+    const res = await fetch('/api/order-returns', {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify(body)
+    })
+    if (!res.ok) throw new Error('Failed to create return')
+    await res.json()
+    newReturn.value = { orderId:'', customerId:'', reason:'', items:'[]', customerNote:'', refundAmount:0, currency:'' }
+    fetchReturns()
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+async function updateStatus(id: string) {
+  const status = statusUpdates.value[id]
+  if (!status) return
+  try {
+    const res = await fetch(`/api/order-returns/${id}/status`, {
+      method:'PATCH',
+      headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify({ status })
+    })
+    if (!res.ok) throw new Error('Failed to update status')
+    await res.json()
+    fetchReturns()
+  } catch (err) {
+    console.error(err)
+  }
+}
+</script>
+
+<style scoped>
+.returns-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.returns-table th,
+.returns-table td {
+  padding: 8px;
+  border: 1px solid #ddd;
+  text-align: left;
+}
+
+.state {
+  margin: 20px 0;
+}
+
+.state.error {
+  color: red;
+}
+
+.create-form {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.create-form input,
+.create-form textarea {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+}
+</style>


### PR DESCRIPTION
## Summary
- add admin routes and sidebar links for claims, exchanges, and returns
- implement minimal Vue components for managing order claims, exchanges, and returns
- include descriptions for new pages in App header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3645861208331b0ffea602949eb93