### PR TITLE
refactor: replace Mongo ObjectId with UUID

### DIFF
--- a/src/entities/ApiKey.ts
+++ b/src/entities/ApiKey.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -15,10 +14,7 @@ import * as crypto from "crypto";
 
 @Entity("api_keys")
 export class ApiKey {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()
@@ -46,11 +42,11 @@ export class ApiKey {
   })
   status: ApiKeyStatus;
 
-  @Column({ type: "array", default: [] })
+  @Column({ type: "simple-array", default: [] })
   @IsArray()
   permissions: Permission[]; // Specific permissions for this key
 
-  @Column({ type: "array", default: [] })
+  @Column({ type: "simple-array", default: [] })
   @IsArray()
   scopes: string[]; // API scopes (e.g., "orders", "products", "customers")
 
@@ -69,7 +65,7 @@ export class ApiKey {
   @IsOptional()
   rateLimitPerHour?: number; // Rate limit for this specific key
 
-  @Column({ type: "array", default: [] })
+  @Column({ type: "simple-array", default: [] })
   @IsArray()
   allowedIPs: string[]; // IP whitelist
 

--- a/src/entities/Campaign.ts
+++ b/src/entities/Campaign.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -16,10 +15,7 @@ import { CampaignTargetType } from "../enums/campaign_target_type"; // Assuming 
 
 @Entity("campaigns")
 export class Campaign {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/Cart.ts
+++ b/src/entities/Cart.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -14,10 +13,7 @@ import { CartType } from "../enums/cart_type";
 
 @Entity("carts")
 export class Cart {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column({

--- a/src/entities/Category.ts
+++ b/src/entities/Category.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -14,10 +13,7 @@ import { v4 as uuidv4 } from "uuid";
 
 @Entity("categories")
 export class Category {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/Collection.ts
+++ b/src/entities/Collection.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -15,10 +14,7 @@ import { CollectionType } from "../enums/collection_type"; // Assuming Collectio
 
 @Entity("collections")
 export class Collection {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/Customer.ts
+++ b/src/entities/Customer.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -15,10 +14,7 @@ import { CustomerStatus } from "../enums/customer_status"; // Assuming CustomerS
 
 @Entity("customers")
 export class Customer {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/CustomerGroup.ts
+++ b/src/entities/CustomerGroup.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -12,10 +11,7 @@ import { v4 as uuidv4 } from "uuid";
 
 @Entity("customer-groups")
 export class CustomerGroup {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/FulfillmentCenter.ts
+++ b/src/entities/FulfillmentCenter.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -13,10 +12,7 @@ import { FulfillmentCenterStatus } from "../enums/fulfillment_center_status";
 
 @Entity("fulfillment_centers")
 export class FulfillmentCenter {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()
@@ -104,7 +100,7 @@ export class FulfillmentCenter {
   isDefault: boolean; // Default fulfillment center
 
   // Supported shipping zones
-  @Column({ type: "array", default: [] })
+  @Column({ type: "simple-array", default: [] })
   supportedShippingZones: string[]; // Array of shipping zone IDs
 
   // Priority for order routing

--- a/src/entities/Inventory.ts
+++ b/src/entities/Inventory.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -12,10 +11,7 @@ import { v4 as uuidv4 } from "uuid";
 
 @Entity("inventory")
 export class Inventory {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/InventoryLevel.ts
+++ b/src/entities/InventoryLevel.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -12,10 +11,7 @@ import { v4 as uuidv4 } from "uuid";
 
 @Entity("inventory_levels")
 export class InventoryLevel {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/OAuthAccount.ts
+++ b/src/entities/OAuthAccount.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -16,10 +15,7 @@ import { User } from "./User";
 
 @Entity("oauth_accounts")
 export class OAuthAccount {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @ManyToOne(() => User, { eager: false })

--- a/src/entities/Order.ts
+++ b/src/entities/Order.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -15,10 +14,7 @@ import { OrderFinancialStatus } from "../enums/order_financial_status"; // Assum
 
 @Entity("orders")
 export class Order {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column({ unique: true })

--- a/src/entities/OrderClaim.ts
+++ b/src/entities/OrderClaim.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -14,10 +13,7 @@ import { ClaimType } from "../enums/claim_type";
 
 @Entity("order_claims")
 export class OrderClaim {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/OrderExchange.ts
+++ b/src/entities/OrderExchange.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -13,10 +12,7 @@ import { ExchangeStatus } from "../enums/exchange_status";
 
 @Entity("order_exchanges")
 export class OrderExchange {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/OrderReturn.ts
+++ b/src/entities/OrderReturn.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -14,10 +13,7 @@ import { ReturnReason } from "../enums/return_reason";
 
 @Entity("order_returns")
 export class OrderReturn {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/Payment.ts
+++ b/src/entities/Payment.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -14,10 +13,7 @@ import { PaymentMethod } from "../enums/payment_method"; // Assuming PaymentMeth
 
 @Entity("payments")
 export class Payment {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/PaymentIntent.ts
+++ b/src/entities/PaymentIntent.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -27,10 +26,7 @@ export enum PaymentIntentCaptureMethod {
 
 @Entity("payment_intents")
 export class PaymentIntent {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/PriceList.ts
+++ b/src/entities/PriceList.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -14,10 +13,7 @@ import { PriceListType } from "../enums/price_list_type";
 
 @Entity("price_lists")
 export class PriceList {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/Product.ts
+++ b/src/entities/Product.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -16,10 +15,7 @@ import { ProductType } from "../enums/product_type"; // Assuming ProductType is 
 
 @Entity("products")
 export class Product {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/ProductOption.ts
+++ b/src/entities/ProductOption.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -12,10 +11,7 @@ import { v4 as uuidv4 } from "uuid";
 
 @Entity("product-options")
 export class ProductOption {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/Promotion.ts
+++ b/src/entities/Promotion.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -15,10 +14,7 @@ import { PromotionTargetType } from "../enums/promotion_target_type"; // Assumin
 
 @Entity("promotions")
 export class Promotion {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/Refund.ts
+++ b/src/entities/Refund.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -28,10 +27,7 @@ export enum RefundReason {
 
 @Entity("refunds")
 export class Refund {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/Review.ts
+++ b/src/entities/Review.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -13,10 +12,7 @@ import { ReviewStatus } from "../enums/review_status";
 
 @Entity("reviews")
 export class Review {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/Role.ts
+++ b/src/entities/Role.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -13,10 +12,7 @@ import { Permission } from "../enums/permission";
 
 @Entity("roles")
 export class Role {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column({ unique: true })
@@ -27,7 +23,7 @@ export class Role {
   @IsOptional()
   description?: string;
 
-  @Column({ type: "array" })
+  @Column({ type: "simple-array" })
   @IsArray()
   permissions: Permission[];
 

--- a/src/entities/SalesChannel.ts
+++ b/src/entities/SalesChannel.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -12,10 +11,7 @@ import { v4 as uuidv4 } from "uuid";
 
 @Entity("sales_channels")
 export class SalesChannel {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/SavedPaymentMethod.ts
+++ b/src/entities/SavedPaymentMethod.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -29,10 +28,7 @@ export enum PaymentMethodType {
 
 @Entity("saved_payment_methods")
 export class SavedPaymentMethod {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/Shipment.ts
+++ b/src/entities/Shipment.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -13,10 +12,7 @@ import { ShipmentStatus } from "../enums/shipment_status";
 
 @Entity("shipments")
 export class Shipment {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/ShippingProvider.ts
+++ b/src/entities/ShippingProvider.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -48,10 +47,7 @@ function decrypt(text: string): string {
 
 @Entity("shipping_providers")
 export class ShippingProvider {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/ShippingRate.ts
+++ b/src/entities/ShippingRate.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -13,10 +12,7 @@ import { ShippingRateType } from "../enums/shipping_rate_type";
 
 @Entity("shipping_rates")
 export class ShippingRate {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/ShippingZone.ts
+++ b/src/entities/ShippingZone.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -12,10 +11,7 @@ import { v4 as uuidv4 } from "uuid";
 
 @Entity("shipping_zones")
 export class ShippingZone {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -1,22 +1,22 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
   BeforeInsert,
   BeforeUpdate,
+  PrimaryColumn,
 } from "typeorm";
 import { IsEmail, IsNotEmpty, MinLength, IsOptional } from "class-validator";
 import * as bcrypt from "bcryptjs";
+import { v4 as uuidv4 } from "uuid";
 import { UserRole } from "../enums/user_role"; // Assuming UserRole is defined in a separate file
 import { UserAddress } from "../enums/user_address"; // Assuming UserAddress is defined in a separate file
 
 @Entity("users")
 export class User {
-  @ObjectIdColumn()
-  id!: ObjectId;
+  @PrimaryColumn("uuid")
+  id!: string;
 
   @Column()
   @IsEmail()
@@ -46,7 +46,7 @@ export class User {
   @Column({ type: "enum", enum: UserRole, default: UserRole.CUSTOMER })
   role!: UserRole;
 
-  @Column({ type: "array", default: [] })
+  @Column({ type: "simple-array", default: [] })
   roleIds: string[]; // References to Role entities for RBAC
 
   @Column({ default: true })
@@ -94,6 +94,11 @@ export class User {
 
   @UpdateDateColumn()
   updatedAt!: Date;
+
+  @BeforeInsert()
+  generateId() {
+    this.id = uuidv4();
+  }
 
   @BeforeInsert()
   @BeforeUpdate()

--- a/src/entities/WebhookEvent.ts
+++ b/src/entities/WebhookEvent.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   BeforeInsert,
@@ -64,10 +63,7 @@ export enum WebhookStatus {
 
 @Entity("webhook_events")
 export class WebhookEvent {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column({

--- a/src/entities/Wishlist.ts
+++ b/src/entities/Wishlist.ts
@@ -1,7 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
-  ObjectId,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -12,10 +11,7 @@ import { v4 as uuidv4 } from "uuid";
 
 @Entity("wishlists")
 export class Wishlist {
-  @ObjectIdColumn()
-  _id: ObjectId;
-
-  @Column()
+  @PrimaryColumn("uuid")
   id: string;
 
   @Column()


### PR DESCRIPTION
## Summary
- switch all entities from `ObjectIdColumn` to UUID `PrimaryColumn`
- replace unsupported `array` column type with `simple-array` for MySQL
- generate UUIDs for users and other records

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b368c3e5f08331bc2fbf146e4da565