### PR TITLE
feat: add admin login form and API integration

### DIFF
--- a/admin/src/views/Login.vue
+++ b/admin/src/views/Login.vue
@@ -28,15 +28,14 @@ async function login() {
       body: JSON.stringify({ email: email.value, password: password.value })
     })
 
+    const data = await response.json()
     if (!response.ok) {
-      const data = await response.json()
       throw new Error(data.error || 'Login failed')
     }
 
-    const data = await response.json()
     localStorage.setItem('accessToken', data.tokens.accessToken)
     localStorage.setItem('refreshToken', data.tokens.refreshToken)
-    router.push('/')
+    router.push('/products')
   } catch (err: any) {
     error.value = err.message
   }


### PR DESCRIPTION
## Summary
- implement admin login form that calls backend auth API
- store received tokens and redirect to products page

## Testing
- `npm test`
- `cd admin && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b3b8fb639c833181b29241455db26a