### PR TITLE
Fetch collections from backend and enable edit navigation

### DIFF
--- a/admin/src/api/collections.ts
+++ b/admin/src/api/collections.ts
@@ -1,0 +1,21 @@
+export interface CollectionPayload {
+  title: string
+  description?: string
+  handle?: string
+}
+
+export async function getCollections() {
+  const res = await fetch('/collections')
+  if (!res.ok) {
+    throw new Error('Failed to fetch collections')
+  }
+  return res.json()
+}
+
+export async function getCollection(id: string) {
+  const res = await fetch(`/collections/${id}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch collection')
+  }
+  return res.json()
+}

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -33,6 +33,11 @@ const routes: RouteRecordRaw[] = [
     component: () => import('../views/products/CollectionCreate.vue')
   },
   {
+    path: '/products/collections/:id',
+    name: 'EditCollection',
+    component: () => import('../views/products/CollectionEdit.vue')
+  },
+  {
     path: '/products/categories',
     name: 'Categories',
     component: () => import('../views/products/CategoriesList.vue')

--- a/admin/src/views/products/CollectionEdit.vue
+++ b/admin/src/views/products/CollectionEdit.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="edit-collection">
+    <h2>Edit Collection</h2>
+    <p>Update your collection details.</p>
+
+    <form @submit.prevent="saveCollection">
+      <div class="form-group">
+        <label for="title">Title</label>
+        <input
+          id="title"
+          type="text"
+          v-model="collectionForm.title"
+          class="form-control"
+          required
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="handle">
+          Handle
+          <span class="info-icon" title="Optional unique identifier for the collection">ⓘ</span>
+          <span class="optional">(Optional)</span>
+        </label>
+        <div class="handle-input">
+          <span class="handle-prefix">/</span>
+          <input
+            id="handle"
+            type="text"
+            v-model="collectionForm.handle"
+            class="form-control"
+            placeholder=""
+          />
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <button type="button" class="btn btn-secondary" @click="cancel">Cancel</button>
+        <button type="submit" class="btn btn-primary">Save Collection</button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { getCollection } from '../../api/collections';
+
+const router = useRouter();
+const route = useRoute();
+
+const collectionForm = ref({
+  title: '',
+  handle: ''
+});
+
+onMounted(async () => {
+  try {
+    const id = route.params.id as string;
+    const data = await getCollection(id);
+    const c = data.collection;
+    collectionForm.value = {
+      title: c.title,
+      handle: c.slug
+    };
+  } catch (error) {
+    console.error('Failed to load collection:', error);
+  }
+});
+
+const saveCollection = async () => {
+  try {
+    // TODO: Implement API call to update collection
+    console.log('Saving collection:', collectionForm.value);
+    router.push('/products/collections');
+  } catch (error) {
+    console.error('Failed to save collection:', error);
+  }
+};
+
+const cancel = () => {
+  router.push('/products/collections');
+};
+</script>
+
+<style scoped>
+.edit-collection {
+  padding: 20px;
+}
+
+h2 {
+  margin-bottom: 10px;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.form-control {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.info-icon {
+  color: #777;
+  cursor: help;
+}
+
+.optional {
+  color: #777;
+  font-weight: normal;
+  font-size: 0.9em;
+}
+
+.handle-input {
+  display: flex;
+  align-items: center;
+}
+
+.handle-prefix {
+  padding: 8px;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-right: none;
+  border-radius: 4px 0 0 4px;
+}
+
+.handle-input .form-control {
+  border-radius: 0 4px 4px 0;
+}
+
+.form-actions {
+  margin-top: 30px;
+  display: flex;
+  gap: 10px;
+}
+
+.btn {
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-primary {
+  background-color: #4a6cf7;
+  color: white;
+  border: none;
+}
+
+.btn-secondary {
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+}
+</style>

--- a/admin/src/views/products/CollectionsList.vue
+++ b/admin/src/views/products/CollectionsList.vue
@@ -34,11 +34,15 @@
       </thead>
       <tbody>
         <tr v-for="collection in collections" :key="collection.id">
-          <td>{{ collection.title }}</td>
+          <td>
+            <router-link :to="`/products/collections/${collection.id}`" class="collection-link">
+              {{ collection.title }}
+            </router-link>
+          </td>
           <td>/{{ collection.handle }}</td>
           <td>{{ collection.productsCount || '-' }}</td>
           <td class="actions-cell">
-            <button class="btn-menu">⋯</button>
+            <button class="btn-menu" @click="navigateToEdit(collection.id)">⋯</button>
           </td>
         </tr>
         <tr v-if="collections.length === 0">
@@ -63,6 +67,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
+import { getCollections } from '../../api/collections';
 
 const router = useRouter();
 const searchQuery = ref('');
@@ -79,16 +84,13 @@ onMounted(async () => {
 
 const fetchCollections = async () => {
   try {
-    // TODO: Replace with actual API call
-    // Mocking data for now based on the screenshot
-    collections.value = [
-      {
-        id: '1',
-        title: 'd',
-        handle: 'd',
-        productsCount: 0
-      }
-    ];
+    const data = await getCollections();
+    collections.value = data.collections.map((c: any) => ({
+      id: c.id,
+      title: c.title,
+      handle: c.slug,
+      productsCount: c.productIds ? c.productIds.length : 0
+    }));
   } catch (error) {
     console.error('Failed to fetch collections:', error);
   }
@@ -96,6 +98,10 @@ const fetchCollections = async () => {
 
 const navigateToCreate = () => {
   router.push('/products/collections/create');
+};
+
+const navigateToEdit = (id: string) => {
+  router.push(`/products/collections/${id}`);
 };
 </script>
 
@@ -235,5 +241,14 @@ const navigateToCreate = () => {
 .btn-page:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.collection-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.collection-link:hover {
+  text-decoration: underline;
 }
 </style>


### PR DESCRIPTION
## Summary
- list collections from backend API
- add navigation to create and edit collection forms
- add dedicated edit collection view and routing

## Testing
- `npm test`
- `npm --prefix admin run build` *(fails: 'Wishlist' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled; 'IconPlus' is declared but its value is never read; 'IconX' is declared but its value is never read; 'props' is declared but its value is never read)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b9005968833183601c1c78910ce4