### PR TITLE
feat: manage customer groups

### DIFF
--- a/admin/src/views/CustomerGroupsList.vue
+++ b/admin/src/views/CustomerGroupsList.vue
@@ -1,10 +1,137 @@
 <template>
-  <div>
-    <h1>Customer Groups</h1>
-    <!-- TODO: implement customer groups list interface -->
+  <div class="p-4">
+    <h1 class="text-2xl mb-4">Customer Groups</h1>
+
+    <form @submit.prevent="saveGroup" class="mb-4 space-y-2">
+      <div>
+        <input
+          v-model="form.name"
+          type="text"
+          placeholder="Group name"
+          class="border p-2 w-full"
+          required
+        />
+      </div>
+      <div>
+        <input
+          v-model="form.description"
+          type="text"
+          placeholder="Description"
+          class="border p-2 w-full"
+        />
+      </div>
+      <div>
+        <input
+          v-model.number="form.discountPercentage"
+          type="number"
+          placeholder="Discount %"
+          class="border p-2 w-full"
+        />
+      </div>
+      <div class="flex items-center space-x-2">
+        <input v-model="form.isActive" type="checkbox" id="isActive" />
+        <label for="isActive">Active</label>
+      </div>
+      <div class="space-x-2">
+        <button type="submit" class="bg-blue-500 text-white px-4 py-1 rounded">
+          {{ form.id ? 'Update' : 'Create' }}
+        </button>
+        <button
+          v-if="form.id"
+          type="button"
+          @click="resetForm"
+          class="px-4 py-1 border rounded"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="bg-gray-100">
+          <th class="border p-2 text-left">Name</th>
+          <th class="border p-2 text-left">Discount</th>
+          <th class="border p-2 text-left">Active</th>
+          <th class="border p-2">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="group in groups" :key="group.id" class="hover:bg-gray-50">
+          <td class="border p-2">{{ group.name }}</td>
+          <td class="border p-2">{{ group.discountPercentage }}%</td>
+          <td class="border p-2">{{ group.isActive ? 'Yes' : 'No' }}</td>
+          <td class="border p-2 space-x-2 text-center">
+            <button
+              @click="editGroup(group)"
+              class="text-blue-600 hover:underline"
+            >Edit</button>
+            <button
+              @click="deleteGroup(group.id)"
+              class="text-red-600 hover:underline"
+            >Delete</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </template>
 
 <script setup lang="ts">
-// TODO: fetch and display customer groups
+import { ref, onMounted } from 'vue'
+
+interface CustomerGroup {
+  id: string
+  name: string
+  description?: string
+  discountPercentage: number
+  isActive: boolean
+}
+
+const groups = ref<CustomerGroup[]>([])
+const form = ref<Partial<CustomerGroup>>({
+  name: '',
+  description: '',
+  discountPercentage: 0,
+  isActive: true
+})
+
+const fetchGroups = async () => {
+  const res = await fetch('/api/customer-groups')
+  const data = await res.json()
+  groups.value = data.customerGroups || []
+}
+
+const saveGroup = async () => {
+  if (form.value.id) {
+    await fetch(`/api/customer-groups/${form.value.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form.value)
+    })
+  } else {
+    await fetch('/api/customer-groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form.value)
+    })
+  }
+  resetForm()
+  fetchGroups()
+}
+
+const editGroup = (group: CustomerGroup) => {
+  form.value = { ...group }
+}
+
+const deleteGroup = async (id: string) => {
+  await fetch(`/api/customer-groups/${id}`, { method: 'DELETE' })
+  fetchGroups()
+}
+
+const resetForm = () => {
+  form.value = { name: '', description: '', discountPercentage: 0, isActive: true }
+}
+
+onMounted(fetchGroups)
 </script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { requestLogger } from "./middleware/requestLogger";
 import productRoutes from "./routes/products";
 import categoryRoutes from "./routes/categories";
 import customerRoutes from "./routes/customers";
+import customerGroupRoutes from "./routes/customer-groups";
 import userRoutes from "./routes/users";
 import authDemoRoutes from "./routes/auth-demo";
 import customerDemoRoutes from "./routes/customer-demo";
@@ -109,6 +110,7 @@ app.get("/health", (req, res) => {
 app.use("/api/products", productRoutes);
 app.use("/api/categories", categoryRoutes);
 app.use("/api/customers", customerRoutes);
+app.use("/api/customer-groups", customerGroupRoutes);
 app.use("/api/users", userRoutes);
 app.use("/api/auth-demo", authDemoRoutes);
 app.use("/api/customer-demo", customerDemoRoutes);

--- a/src/routes/customer-groups.ts
+++ b/src/routes/customer-groups.ts
@@ -1,0 +1,129 @@
+import { Router, Request, Response } from "express";
+import { Like } from "typeorm";
+import { AppDataSource } from "../data-source";
+import { CustomerGroup } from "../entities/CustomerGroup";
+import { validate } from "class-validator";
+import logger from "../utils/logger";
+
+const router = Router();
+
+// Get all customer groups with basic pagination and search
+router.get("/", async (req: Request, res: Response) => {
+  try {
+    const { page = 1, limit = 50, search, isActive } = req.query;
+
+    const customerGroupRepository = AppDataSource.getRepository(CustomerGroup);
+
+    const where: any = {};
+    if (typeof search === "string" && search.length > 0) {
+      where.name = Like(`%${search}%`);
+    }
+    if (isActive !== undefined) {
+      where.isActive = isActive === "true";
+    }
+
+    const [customerGroups, total] = await customerGroupRepository.findAndCount({
+      where,
+      skip: (Number(page) - 1) * Number(limit),
+      take: Number(limit),
+      order: { createdAt: "DESC" },
+    });
+
+    res.json({
+      customerGroups,
+      pagination: {
+        page: Number(page),
+        limit: Number(limit),
+        total,
+        pages: Math.ceil(total / Number(limit)),
+      },
+    });
+  } catch (error) {
+    logger.error("Error fetching customer groups:", error);
+    res.status(500).json({ error: "Failed to fetch customer groups" });
+  }
+});
+
+// Get single customer group by ID
+router.get("/:id", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const customerGroupRepository = AppDataSource.getRepository(CustomerGroup);
+
+    const group = await customerGroupRepository.findOne({ where: { id } });
+
+    if (!group) {
+      return res.status(404).json({ error: "Customer group not found" });
+    }
+
+    res.json(group);
+  } catch (error) {
+    logger.error("Error fetching customer group:", error);
+    res.status(500).json({ error: "Failed to fetch customer group" });
+  }
+});
+
+// Create customer group
+router.post("/", async (req: Request, res: Response) => {
+  try {
+    const customerGroupRepository = AppDataSource.getRepository(CustomerGroup);
+    const group = customerGroupRepository.create(req.body);
+
+    const errors = await validate(group);
+    if (errors.length > 0) {
+      return res.status(400).json({ errors });
+    }
+
+    const saved = await customerGroupRepository.save(group);
+    res.status(201).json(saved);
+  } catch (error) {
+    logger.error("Error creating customer group:", error);
+    res.status(500).json({ error: "Failed to create customer group" });
+  }
+});
+
+// Update customer group
+router.put("/:id", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const customerGroupRepository = AppDataSource.getRepository(CustomerGroup);
+
+    const group = await customerGroupRepository.findOne({ where: { id } });
+    if (!group) {
+      return res.status(404).json({ error: "Customer group not found" });
+    }
+
+    Object.assign(group, req.body);
+
+    const errors = await validate(group);
+    if (errors.length > 0) {
+      return res.status(400).json({ errors });
+    }
+
+    const updated = await customerGroupRepository.save(group);
+    res.json(updated);
+  } catch (error) {
+    logger.error("Error updating customer group:", error);
+    res.status(500).json({ error: "Failed to update customer group" });
+  }
+});
+
+// Delete customer group
+router.delete("/:id", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const customerGroupRepository = AppDataSource.getRepository(CustomerGroup);
+
+    const result = await customerGroupRepository.delete(id);
+    if (result.affected === 0) {
+      return res.status(404).json({ error: "Customer group not found" });
+    }
+
+    res.json({ message: "Customer group deleted" });
+  } catch (error) {
+    logger.error("Error deleting customer group:", error);
+    res.status(500).json({ error: "Failed to delete customer group" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add API routes for listing and modifying customer groups
- expose customer group routes in server setup
- build admin page to create, edit and delete customer groups

## Testing
- `npm test`
- `npm --prefix admin run build` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b9105a64833183991e3695388379