### PR TITLE
feat: extend customer wishlist

### DIFF
--- a/admin/src/api/customers.ts
+++ b/admin/src/api/customers.ts
@@ -23,3 +23,7 @@ export function removeWishlistItem(customerId: string, productId: string) {
   return httpClient.delete<WishlistResponse>(`/customers/${customerId}/wishlist/${productId}`)
 }
 
+export function transferWishlistItemToOrder(customerId: string, productId: string) {
+  return httpClient.post(`/customers/${customerId}/wishlist/${productId}/transfer`, {})
+}
+

--- a/admin/src/views/customers/CustomerWishlist.vue
+++ b/admin/src/views/customers/CustomerWishlist.vue
@@ -6,9 +6,10 @@
       <button @click="addItem">Add</button>
     </div>
     <ul>
-      <li v-for="id in wishlist.productIds" :key="id">
-        {{ id }}
-        <button @click="removeItem(id)">Remove</button>
+      <li v-for="product in products" :key="product.id">
+        {{ product.title || product.id }}
+        <button @click="removeItem(product.id)">Remove</button>
+        <button @click="transferToOrder(product.id)">Transfer to Order</button>
       </li>
     </ul>
   </div>
@@ -17,16 +18,27 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import { getCustomerWishlist, addWishlistItem, removeWishlistItem, Wishlist } from '../../api/customers'
+import httpClient from '../../api/httpClient'
+import { getCustomerWishlist, addWishlistItem, removeWishlistItem, transferWishlistItemToOrder, Wishlist } from '../../api/customers'
 
 const route = useRoute()
 const customerId = route.params.id as string
 const wishlist = ref<Wishlist>({ id: '', customerId, productIds: [] })
+const products = ref<any[]>([])
 const newProductId = ref('')
 
 async function fetchWishlist() {
   const response = await getCustomerWishlist(customerId)
   wishlist.value = response.data
+  products.value = await Promise.all(
+    wishlist.value.productIds.map(async (id) => {
+      try {
+        return await httpClient.get<any>(`/products/${id}`)
+      } catch {
+        return { id, title: id }
+      }
+    })
+  )
 }
 
 async function addItem() {
@@ -38,6 +50,11 @@ async function addItem() {
 
 async function removeItem(id: string) {
   await removeWishlistItem(customerId, id)
+  await fetchWishlist()
+}
+
+async function transferToOrder(id: string) {
+  await transferWishlistItemToOrder(customerId, id)
   await fetchWishlist()
 }
 

--- a/src/routes/wishlists.ts
+++ b/src/routes/wishlists.ts
@@ -1,6 +1,11 @@
 import { Router, Request, Response } from "express";
 import { AppDataSource } from "../data-source";
 import { Wishlist } from "../entities/Wishlist";
+import { Product } from "../entities/Product";
+import { Order } from "../entities/Order";
+import { OrderStatus } from "../enums/order_status";
+import { OrderFulfillmentStatus } from "../enums/order_fulfillment_status";
+import { OrderFinancialStatus } from "../enums/order_financial_status";
 import { authenticateCustomer, CustomerAuthRequest } from "../middleware/customerAuth";
 
 const router = Router();
@@ -86,6 +91,65 @@ router.delete(
     await repository.save(wishlist);
 
     res.json({ success: true, data: wishlist });
+  }
+);
+
+// Transfer wishlist item to order
+router.post(
+  "/customers/:customerId/wishlist/:productId/transfer",
+  authenticateCustomer,
+  async (req: CustomerAuthRequest, res: Response) => {
+    const { customerId, productId } = req.params;
+
+    if (!req.customer || req.customer.id !== customerId) {
+      return res.status(403).json({ error: "Access denied" });
+    }
+
+    const productRepo = AppDataSource.getRepository(Product);
+    const orderRepo = AppDataSource.getRepository(Order);
+    const wishlistRepo = AppDataSource.getRepository(Wishlist);
+
+    const product = await productRepo.findOne({ where: { id: productId } });
+    if (!product) {
+      return res.status(404).json({ error: "Product not found" });
+    }
+
+    // Create a minimal order for the product
+    const order = orderRepo.create({
+      orderNumber: `WL-${Date.now()}`,
+      status: OrderStatus.PENDING,
+      fulfillmentStatus: OrderFulfillmentStatus.UNFULFILLED,
+      financialStatus: OrderFinancialStatus.PENDING,
+      subtotal: 0,
+      taxAmount: 0,
+      shippingAmount: 0,
+      discountAmount: 0,
+      total: 0,
+      currency: "USD",
+      tags: [],
+      items: [
+        {
+          id: product.id,
+          quantity: 1,
+          price: 0,
+          total: 0,
+          productTitle: product.title,
+          variantTitle: "",
+        },
+      ],
+      customerId,
+    });
+
+    await orderRepo.save(order);
+
+    // Remove item from wishlist
+    const wishlist = await wishlistRepo.findOne({ where: { customerId } });
+    if (wishlist) {
+      wishlist.productIds = wishlist.productIds.filter((id) => id !== productId);
+      await wishlistRepo.save(wishlist);
+    }
+
+    res.json({ success: true, data: order });
   }
 );
 


### PR DESCRIPTION
## Summary
- fetch full product data for customer wishlist and display titles
- allow transferring wishlist items to new orders and remove them
- expose API helper and backend endpoint for order transfers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3bc28ced08331b188452afb56baf2