### PR TITLE
feat: add payment provider management

### DIFF
--- a/admin/src/views/settings/PaymentsList.vue
+++ b/admin/src/views/settings/PaymentsList.vue
@@ -1,10 +1,143 @@
 <template>
-  <div>
-    <h1>Payments</h1>
-    <!-- TODO: implement payments list interface -->
+  <div class="payments-container">
+    <h1>Payment Providers</h1>
+
+    <div class="add-provider">
+      <input v-model="newProvider.name" placeholder="Name" />
+      <select v-model="newProvider.type">
+        <option value="stripe">Stripe</option>
+        <option value="paypal">PayPal</option>
+        <option value="manual">Manual</option>
+      </select>
+      <button @click="addProvider">Add</button>
+    </div>
+
+    <div v-if="loading">Loading...</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+
+    <table v-else class="providers-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="provider in providers" :key="provider.id">
+          <td>{{ provider.name }}</td>
+          <td>{{ provider.type }}</td>
+          <td>{{ provider.isEnabled ? 'Enabled' : 'Disabled' }}</td>
+          <td>
+            <button @click="toggleProvider(provider)">
+              {{ provider.isEnabled ? 'Disable' : 'Enable' }}
+            </button>
+          </td>
+        </tr>
+        <tr v-if="providers.length === 0">
+          <td colspan="4">No payment providers found</td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </template>
 
 <script setup lang="ts">
-// TODO: fetch and display payments
+import { ref, onMounted } from 'vue'
+
+interface PaymentProvider {
+  id: string
+  name: string
+  type: string
+  isEnabled: boolean
+}
+
+const providers = ref<PaymentProvider[]>([])
+const loading = ref(false)
+const error = ref('')
+
+const newProvider = ref({ name: '', type: 'stripe' })
+
+const fetchProviders = async () => {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await fetch('/api/payment-providers')
+    if (!res.ok) throw new Error('Failed to fetch payment providers')
+    const data = await res.json()
+    providers.value = data.providers || []
+  } catch (err: any) {
+    error.value = err.message || 'Error loading providers'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchProviders)
+
+const addProvider = async () => {
+  if (!newProvider.value.name) return
+  try {
+    const res = await fetch('/api/payment-providers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: newProvider.value.name,
+        type: newProvider.value.type
+      })
+    })
+    if (!res.ok) throw new Error('Failed to add provider')
+    const data = await res.json()
+    providers.value.push(data)
+    newProvider.value.name = ''
+    newProvider.value.type = 'stripe'
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+const toggleProvider = async (provider: PaymentProvider) => {
+  try {
+    const res = await fetch(`/api/payment-providers/${provider.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isEnabled: !provider.isEnabled })
+    })
+    if (!res.ok) throw new Error('Failed to update provider')
+    const data = await res.json()
+    provider.isEnabled = data.isEnabled
+  } catch (err) {
+    console.error(err)
+  }
+}
 </script>
+
+<style scoped>
+.payments-container {
+  padding: 1rem;
+}
+
+.add-provider {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.providers-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.providers-table th,
+.providers-table td {
+  padding: 8px;
+  border: 1px solid #ddd;
+  text-align: left;
+}
+
+.error {
+  color: red;
+  margin: 1rem 0;
+}
+</style>

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -16,6 +16,7 @@ import { OrderReturn } from "./entities/OrderReturn";
 import { OrderClaim } from "./entities/OrderClaim";
 import { OrderExchange } from "./entities/OrderExchange";
 import { Payment } from "./entities/Payment";
+import { PaymentProvider } from "./entities/PaymentProvider";
 import { Promotion } from "./entities/Promotion";
 import { Campaign } from "./entities/Campaign";
 import { ProductOption } from "./entities/ProductOption";
@@ -60,6 +61,7 @@ export const AppDataSource = new DataSource({
     OrderClaim,
     OrderExchange,
     Payment,
+    PaymentProvider,
     Promotion,
     Campaign,
     PriceList,

--- a/src/entities/PaymentProvider.ts
+++ b/src/entities/PaymentProvider.ts
@@ -1,0 +1,36 @@
+import { Entity, PrimaryColumn, Column, CreateDateColumn, UpdateDateColumn, BeforeInsert } from "typeorm";
+import { IsNotEmpty, IsEnum, IsOptional } from "class-validator";
+import { v4 as uuidv4 } from "uuid";
+import { PaymentProviderType } from "../enums/payment_provider_type";
+
+@Entity("payment_providers")
+export class PaymentProvider {
+  @PrimaryColumn("uuid")
+  id: string;
+
+  @Column()
+  @IsNotEmpty()
+  name: string;
+
+  @Column({ type: "enum", enum: PaymentProviderType })
+  @IsEnum(PaymentProviderType)
+  type: PaymentProviderType;
+
+  @Column({ default: true })
+  isEnabled: boolean;
+
+  @Column({ type: "json", nullable: true })
+  @IsOptional()
+  config?: Record<string, any>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @BeforeInsert()
+  generateId() {
+    this.id = uuidv4();
+  }
+}

--- a/src/enums/payment_provider_type.ts
+++ b/src/enums/payment_provider_type.ts
@@ -1,0 +1,5 @@
+export enum PaymentProviderType {
+  STRIPE = "stripe",
+  PAYPAL = "paypal",
+  MANUAL = "manual"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import shippingZoneRoutes from "./routes/shipping-zones";
 import shippingRateRoutes from "./routes/shipping-rates";
 import fulfillmentCenterRoutes from "./routes/fulfillment-centers";
 import shippingProviderRoutes from "./routes/shipping-providers";
+import paymentProviderRoutes from "./routes/payment-providers";
 import shipmentRoutes from "./routes/shipments";
 import adminAuthRoutes from "./routes/admin-auth";
 import apiKeyRoutes from "./routes/api-keys";
@@ -129,6 +130,7 @@ app.use("/api/shipping-zones", shippingZoneRoutes);
 app.use("/api/shipping-rates", shippingRateRoutes);
 app.use("/api/fulfillment-centers", fulfillmentCenterRoutes);
 app.use("/api/shipping-providers", shippingProviderRoutes);
+app.use("/api/payment-providers", paymentProviderRoutes);
 app.use("/api/shipments", shipmentRoutes);
 app.use("/api/checkout", checkoutRoutes);
 

--- a/src/routes/payment-providers.ts
+++ b/src/routes/payment-providers.ts
@@ -1,0 +1,74 @@
+import { Router, Request, Response } from "express";
+import { AppDataSource } from "../data-source";
+import { PaymentProvider } from "../entities/PaymentProvider";
+import { validate } from "class-validator";
+
+const router = Router();
+
+// Get all payment providers
+router.get("/", async (_req: Request, res: Response) => {
+  try {
+    const repo = AppDataSource.getRepository(PaymentProvider);
+    const providers = await repo.find();
+    res.json({ providers });
+  } catch (err) {
+    logger.error("Error fetching payment providers:", err);
+    res.status(500).json({ error: "Failed to fetch payment providers" });
+  }
+});
+
+// Create payment provider
+router.post("/", async (req: Request, res: Response) => {
+  try {
+    const repo = AppDataSource.getRepository(PaymentProvider);
+    const provider = repo.create(req.body);
+    const errors = await validate(provider);
+    if (errors.length > 0) {
+      return res.status(400).json({ errors });
+    }
+    const saved = await repo.save(provider);
+    res.status(201).json(saved);
+  } catch (err) {
+    logger.error("Error creating payment provider:", err);
+    res.status(500).json({ error: "Failed to create payment provider" });
+  }
+});
+
+// Update payment provider (enable/disable or other fields)
+router.put("/:id", async (req: Request, res: Response) => {
+  try {
+    const repo = AppDataSource.getRepository(PaymentProvider);
+    const provider = await repo.findOne({ where: { id: req.params.id } });
+    if (!provider) {
+      return res.status(404).json({ error: "Payment provider not found" });
+    }
+    Object.assign(provider, req.body);
+    const errors = await validate(provider);
+    if (errors.length > 0) {
+      return res.status(400).json({ errors });
+    }
+    const saved = await repo.save(provider);
+    res.json(saved);
+  } catch (err) {
+    logger.error("Error updating payment provider:", err);
+    res.status(500).json({ error: "Failed to update payment provider" });
+  }
+});
+
+// Delete payment provider
+router.delete("/:id", async (req: Request, res: Response) => {
+  try {
+    const repo = AppDataSource.getRepository(PaymentProvider);
+    const provider = await repo.findOne({ where: { id: req.params.id } });
+    if (!provider) {
+      return res.status(404).json({ error: "Payment provider not found" });
+    }
+    await repo.remove(provider);
+    res.status(204).send();
+  } catch (err) {
+    logger.error("Error deleting payment provider:", err);
+    res.status(500).json({ error: "Failed to delete payment provider" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add PaymentProvider entity and API routes
- wire up payment provider management in admin settings with enable/disable

## Testing
- `npm test` *(fails: ts-jest warnings and test run hangs)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3bc2ffd8c83318e0ade8e5d62f958