### PR TITLE
feat: extract header/footer/navigation components

### DIFF
--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -1,18 +1,50 @@
 <template>
-  <footer class="site-footer">
-    <p>&copy; 2024 My Shop</p>
+  <footer id="sns_footer" class="wrap">
+    <div id="sns_footer_top">
+      <div class="container">
+        <ul class="footer-links">
+          <li><RouterLink to="/">Home</RouterLink></li>
+          <li><RouterLink to="/listing">Listing</RouterLink></li>
+          <li><RouterLink to="/product">Product</RouterLink></li>
+        </ul>
+      </div>
+    </div>
+    <div id="sns_footer_bottom">
+      <div class="container">
+        <p class="copyright">&copy; 2024 E-Shop. All Rights Reserved.</p>
+      </div>
+    </div>
   </footer>
 </template>
 
 <script setup>
+import { RouterLink } from 'vue-router';
 </script>
 
 <style scoped>
-.site-footer {
-  text-align: center;
-  padding: 1rem;
-  background-color: #f0f0f0;
-  border-top: 1px solid #ddd;
+#sns_footer {
   margin-top: 2rem;
+  color: #fff;
+}
+#sns_footer_top {
+  background: #222;
+  padding: 1rem 0;
+}
+#sns_footer_bottom {
+  background: #111;
+  padding: 0.5rem 0;
+  text-align: center;
+}
+.footer-links {
+  display: flex;
+  justify-content: center;
+  list-style: none;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+.footer-links a {
+  color: #fff;
+  text-decoration: none;
 }
 </style>

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -1,18 +1,30 @@
 <template>
-  <header class="site-header">
-    <h1>E-Shop</h1>
+  <header id="sns_header" class="wrap">
+    <div id="sns_header_logo">
+      <RouterLink to="/" id="logo">
+        <img :src="logo" alt="E-Shop logo" />
+      </RouterLink>
+    </div>
     <Navigation />
   </header>
 </template>
 
 <script setup>
 import Navigation from './Navigation.vue';
+import { RouterLink } from 'vue-router';
+
+const logo = new URL('../assets/images/logo.jpg', import.meta.url).href;
 </script>
 
 <style scoped>
-.site-header {
-  padding: 1rem;
-  background-color: #f8f8f8;
-  border-bottom: 1px solid #ddd;
+#sns_header {
+  border-bottom: 1px solid #e5e5e5;
+}
+#sns_header_logo {
+  padding: 1rem 0;
+  text-align: center;
+}
+#logo img {
+  max-height: 60px;
 }
 </style>

--- a/frontend/src/components/Navigation.vue
+++ b/frontend/src/components/Navigation.vue
@@ -1,8 +1,10 @@
 <template>
-  <nav class="nav">
-    <RouterLink to="/">Home</RouterLink>
-    <RouterLink to="/listing">Listing</RouterLink>
-    <RouterLink to="/product">Product</RouterLink>
+  <nav id="sns_menu">
+    <ul class="mainnav">
+      <li class="level0"><RouterLink to="/">Home</RouterLink></li>
+      <li class="level0"><RouterLink to="/listing">Listing</RouterLink></li>
+      <li class="level0"><RouterLink to="/product">Product</RouterLink></li>
+    </ul>
   </nav>
 </template>
 
@@ -11,8 +13,22 @@ import { RouterLink } from 'vue-router';
 </script>
 
 <style scoped>
-.nav {
+#sns_menu {
+  background: #333;
+}
+.mainnav {
   display: flex;
-  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.mainnav li a {
+  display: block;
+  padding: 0.75rem 1rem;
+  color: #fff;
+  text-decoration: none;
+}
+.mainnav li a:hover {
+  background: #444;
 }
 </style>


### PR DESCRIPTION
## Summary
- add header component with logo and navigation
- create navigation component extracted from legacy HTML
- build footer component with shared links and copyright

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42df5400c83318f3c51616171b271