### PR TITLE
feat(frontend): add index3 variant views

### DIFF
--- a/frontend/src/views/BlogDetailVariant3.vue
+++ b/frontend/src/views/BlogDetailVariant3.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="sns_wrapper">
+    <Header />
+    <div id="sns_main" v-html="content"></div>
+    <Footer />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import raw from '../../../website/index3-blog-detail.html?raw';
+
+const content = ref('');
+onMounted(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(raw, 'text/html');
+  content.value = doc.querySelector('#sns_main')?.innerHTML || '';
+});
+</script>
+
+<style scoped lang="less">
+@import "../assets/less/variables.less";
+@import "../assets/less/mixin.less";
+@import "../assets/less/general.less";
+@import "../assets/less/blog.less";
+</style>

--- a/frontend/src/views/BlogVariant3.vue
+++ b/frontend/src/views/BlogVariant3.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="sns_wrapper">
+    <Header />
+    <div id="sns_main" v-html="content"></div>
+    <Footer />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import raw from '../../../website/index3-blog.html?raw';
+
+const content = ref('');
+onMounted(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(raw, 'text/html');
+  content.value = doc.querySelector('#sns_main')?.innerHTML || '';
+});
+</script>
+
+<style scoped lang="less">
+@import "../assets/less/variables.less";
+@import "../assets/less/mixin.less";
+@import "../assets/less/general.less";
+@import "../assets/less/blog.less";
+</style>

--- a/frontend/src/views/ContactUsVariant3.vue
+++ b/frontend/src/views/ContactUsVariant3.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="sns_wrapper">
+    <Header />
+    <div id="sns_main" v-html="content"></div>
+    <Footer />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import raw from '../../../website/index3-contact-us.html?raw';
+
+const content = ref('');
+onMounted(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(raw, 'text/html');
+  content.value = doc.querySelector('#sns_main')?.innerHTML || '';
+});
+</script>
+
+<style scoped lang="less">
+@import "../assets/less/variables.less";
+@import "../assets/less/mixin.less";
+@import "../assets/less/general.less";
+@import "../assets/less/content.less";
+</style>

--- a/frontend/src/views/HomeVariant3.vue
+++ b/frontend/src/views/HomeVariant3.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="sns_wrapper">
+    <Header />
+    <div id="sns_main" v-html="content"></div>
+    <Footer />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import raw from '../../../website/index3.html?raw';
+
+const content = ref('');
+onMounted(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(raw, 'text/html');
+  content.value = doc.querySelector('#sns_main')?.innerHTML || '';
+});
+</script>
+
+<style scoped lang="less">
+@import "../assets/less/variables.less";
+@import "../assets/less/mixin.less";
+@import "../assets/less/general.less";
+@import "../assets/less/home.less";
+</style>

--- a/frontend/src/views/ListingGridVariant3.vue
+++ b/frontend/src/views/ListingGridVariant3.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="sns_wrapper">
+    <Header />
+    <div id="sns_main" v-html="content"></div>
+    <Footer />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import raw from '../../../website/index3-listing-grid.html?raw';
+
+const content = ref('');
+onMounted(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(raw, 'text/html');
+  content.value = doc.querySelector('#sns_main')?.innerHTML || '';
+});
+</script>
+
+<style scoped lang="less">
+@import "../assets/less/variables.less";
+@import "../assets/less/mixin.less";
+@import "../assets/less/general.less";
+@import "../assets/less/listing.less";
+</style>

--- a/frontend/src/views/ListingListVariant3.vue
+++ b/frontend/src/views/ListingListVariant3.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="sns_wrapper">
+    <Header />
+    <div id="sns_main" v-html="content"></div>
+    <Footer />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import raw from '../../../website/index3-listing-list.html?raw';
+
+const content = ref('');
+onMounted(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(raw, 'text/html');
+  content.value = doc.querySelector('#sns_main')?.innerHTML || '';
+});
+</script>
+
+<style scoped lang="less">
+@import "../assets/less/variables.less";
+@import "../assets/less/mixin.less";
+@import "../assets/less/general.less";
+@import "../assets/less/listing.less";
+</style>

--- a/frontend/src/views/NotFoundVariant3.vue
+++ b/frontend/src/views/NotFoundVariant3.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="sns_wrapper">
+    <Header />
+    <div id="sns_main" v-html="content"></div>
+    <Footer />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import raw from '../../../website/index3-404.html?raw';
+
+const content = ref('');
+onMounted(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(raw, 'text/html');
+  content.value = doc.querySelector('#sns_main')?.innerHTML || '';
+});
+</script>
+
+<style scoped lang="less">
+@import "../assets/less/variables.less";
+@import "../assets/less/mixin.less";
+@import "../assets/less/general.less";
+@import "../assets/less/content.less";
+</style>

--- a/frontend/src/views/ProductDetailVariant3.vue
+++ b/frontend/src/views/ProductDetailVariant3.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="sns_wrapper">
+    <Header />
+    <div id="sns_main" v-html="content"></div>
+    <Footer />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import raw from '../../../website/index3-detail.html?raw';
+
+const content = ref('');
+onMounted(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(raw, 'text/html');
+  content.value = doc.querySelector('#sns_main')?.innerHTML || '';
+});
+</script>
+
+<style scoped lang="less">
+@import "../assets/less/variables.less";
+@import "../assets/less/mixin.less";
+@import "../assets/less/general.less";
+@import "../assets/less/detail.less";
+</style>

--- a/frontend/src/views/ShoppingCartVariant3.vue
+++ b/frontend/src/views/ShoppingCartVariant3.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="sns_wrapper">
+    <Header />
+    <div id="sns_main" v-html="content"></div>
+    <Footer />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import raw from '../../../website/index3-shoppingcart.html?raw';
+
+const content = ref('');
+onMounted(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(raw, 'text/html');
+  content.value = doc.querySelector('#sns_main')?.innerHTML || '';
+});
+</script>
+
+<style scoped lang="less">
+@import "../assets/less/variables.less";
+@import "../assets/less/mixin.less";
+@import "../assets/less/general.less";
+@import "../assets/less/shopping-checkout.less";
+</style>


### PR DESCRIPTION
## Summary
- add Vue views that load index3 website markup and wrap with Header/Footer
- include variant-specific LESS styles for each view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4359aa69c833187cd2f0665275879