### PR TITLE
feat: add collection creation endpoint

### DIFF
--- a/admin/src/api/collections.ts
+++ b/admin/src/api/collections.ts
@@ -13,3 +13,7 @@ export async function getCollections() {
 export async function getCollection(id: string) {
   return httpClient.get(`/api/collections/${id}`)
 }
+
+export async function createCollection(payload: CollectionPayload) {
+  return httpClient.post('/api/collections', payload)
+}

--- a/admin/src/views/products/CollectionCreate.vue
+++ b/admin/src/views/products/CollectionCreate.vue
@@ -72,6 +72,7 @@ const createCollection = async () => {
     router.push('/products/collections');
   } catch (error) {
     console.error('Failed to create collection:', error);
+    alert((error as any)?.message || 'Failed to create collection');
   } finally {
     isSubmitting.value = false;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { requestLogger } from "./middleware/requestLogger";
 // Import routes
 import productRoutes from "./routes/products";
 import categoryRoutes from "./routes/categories";
+import collectionRoutes from "./routes/collections";
 import customerRoutes from "./routes/customers";
 import customerGroupRoutes from "./routes/customer-groups";
 import userRoutes from "./routes/users";
@@ -110,6 +111,7 @@ app.get("/health", (req, res) => {
 // API Routes
 app.use("/api/products", productRoutes);
 app.use("/api/categories", categoryRoutes);
+app.use("/api/collections", collectionRoutes);
 app.use("/api/customers", customerRoutes);
 app.use("/api/customer-groups", customerGroupRoutes);
 app.use("/api/users", userRoutes);

--- a/src/routes/collections.ts
+++ b/src/routes/collections.ts
@@ -1,0 +1,28 @@
+import { Router, Request, Response } from "express";
+import { validate } from "class-validator";
+import { AppDataSource } from "../data-source";
+import { Collection } from "../entities/Collection";
+import logger from "../utils/logger";
+
+const router = Router();
+
+// Create collection
+router.post("/", async (req: Request, res: Response) => {
+  try {
+    const collectionRepository = AppDataSource.getRepository(Collection);
+    const collection = collectionRepository.create(req.body);
+
+    const errors = await validate(collection);
+    if (errors.length > 0) {
+      return res.status(400).json({ errors });
+    }
+
+    const saved = await collectionRepository.save(collection);
+    res.status(201).json(saved);
+  } catch (error) {
+    logger.error("Error creating collection:", error);
+    res.status(500).json({ error: "Failed to create collection" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add client helper to post new collections
- expose POST /api/collections on server
- wire up CollectionCreate view with user-facing error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46acac3188331b6ee92625860286d