### PR TITLE
feat: load product categories and collections dynamically

### DIFF
--- a/admin/src/views/products/components/ProductCreateModal.vue
+++ b/admin/src/views/products/components/ProductCreateModal.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { IconX, IconUpload, IconPlus, IconTrash } from '@tabler/icons-vue'
+import MultiSelect from 'primevue/multiselect'
+import { getCategories } from '../../../api/categories'
+import { getCollections } from '../../../api/collections'
 
 const props = defineProps({
   isOpen: {
@@ -33,19 +36,29 @@ const productData = ref({
 })
 
 // Available options for dropdowns
-const availableCategories = ref([
-  { id: '1', name: 'Electronics' },
-  { id: '2', name: 'Computers' },
-  { id: '3', name: 'Gaming' },
-  { id: '4', name: 'Office Equipment' }
-])
+const availableCategories = ref<any[]>([])
+const availableCollections = ref<any[]>([])
 
-const availableCollections = ref([
-  { id: '1', name: 'Winter Sale' },
-  { id: '2', name: 'Summer Collection' },
-  { id: '3', name: 'Gaming Products' },
-  { id: '4', name: 'Professional products' }
-])
+const loadOptions = async () => {
+  try {
+    const [categoriesRes, collectionsRes] = await Promise.all([
+      getCategories(),
+      getCollections()
+    ])
+    const categoryList = Array.isArray(categoriesRes)
+      ? categoriesRes
+      : (categoriesRes.categories || [])
+    const collectionList = Array.isArray(collectionsRes)
+      ? collectionsRes
+      : (collectionsRes.collections || [])
+    availableCategories.value = categoryList
+    availableCollections.value = collectionList
+  } catch (error) {
+    console.error('Failed to load options', error)
+  }
+}
+
+onMounted(loadOptions)
 
 // Form tab state
 const activeTab = ref('general')
@@ -281,22 +294,32 @@ const handleClose = () => {
             
             <div class="form-group">
               <label for="product-categories">Categories</label>
-              <select id="product-categories" v-model="productData.categories" multiple class="form-select">
-                <option v-for="category in availableCategories" :key="category.id" :value="category.id">
-                  {{ category.name }}
-                </option>
-              </select>
-              <p class="help-text">Hold Ctrl/Cmd to select multiple categories</p>
+              <MultiSelect
+                id="product-categories"
+                v-model="productData.categories"
+                :options="availableCategories"
+                optionLabel="name"
+                optionValue="id"
+                filter
+                display="chip"
+                placeholder="Select Categories"
+                class="w-full"
+              />
             </div>
-            
+
             <div class="form-group">
               <label for="product-collections">Collections</label>
-              <select id="product-collections" v-model="productData.collections" multiple class="form-select">
-                <option v-for="collection in availableCollections" :key="collection.id" :value="collection.id">
-                  {{ collection.name }}
-                </option>
-              </select>
-              <p class="help-text">Hold Ctrl/Cmd to select multiple collections</p>
+              <MultiSelect
+                id="product-collections"
+                v-model="productData.collections"
+                :options="availableCollections"
+                optionLabel="name"
+                optionValue="id"
+                filter
+                display="chip"
+                placeholder="Select Collections"
+                class="w-full"
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- fetch categories and collections when the product creation modal mounts
- add searchable PrimeVue MultiSelect inputs for categories and collections

## Testing
- `npm test` (fails: hung with 0 test suites)
- `cd admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46ad5ec388331a803730e1edc7432