### PR TITLE
feat: add option selector for variant assignment

### DIFF
--- a/admin/src/views/products/ProductsList.vue
+++ b/admin/src/views/products/ProductsList.vue
@@ -170,10 +170,14 @@ const handleCreateProduct = async (productData: any) => {
         sku: v.sku,
         price: Number(v.price) || 0,
         inventory: { quantity: Number(v.inventory) || 0 },
-        options: v.options.map((o: any) => ({
-          optionName: o.name,
-          valueName: o.value
-        }))
+        optionValues: v.options
+          .filter((o: any) => o.optionId && o.valueId)
+          .map((o: any) => ({
+            optionId: o.optionId,
+            optionName: o.optionName,
+            valueId: o.valueId,
+            valueName: o.valueName
+          }))
       })),
       collectionIds: productData.collections,
       categoryIds: productData.categories

--- a/admin/src/views/products/components/OptionSelector.vue
+++ b/admin/src/views/products/components/OptionSelector.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { IconPlus, IconTrash } from '@tabler/icons-vue'
+
+interface OptionValue {
+  id: string
+  value: string
+}
+
+interface ProductOption {
+  id: string
+  name: string
+  values: OptionValue[]
+}
+
+interface SelectedOption {
+  optionId: string
+  optionName: string
+  valueId: string
+  valueName: string
+}
+
+const props = defineProps<{ modelValue: SelectedOption[] }>()
+const emit = defineEmits(['update:modelValue'])
+
+const availableOptions = ref<ProductOption[]>([])
+const loading = ref(false)
+
+const fetchOptions = async () => {
+  loading.value = true
+  try {
+    const res = await fetch('/api/product-options')
+    if (res.ok) {
+      const data = await res.json()
+      availableOptions.value = data.options ?? []
+    }
+  } catch (err) {
+    console.error('Failed to fetch product options', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchOptions)
+
+const addOption = () => {
+  emit('update:modelValue', [
+    ...props.modelValue,
+    { optionId: '', optionName: '', valueId: '', valueName: '' }
+  ])
+}
+
+const removeOption = (index: number) => {
+  const updated = [...props.modelValue]
+  updated.splice(index, 1)
+  emit('update:modelValue', updated)
+}
+
+const updateOption = (index: number, field: 'optionId' | 'valueId', value: string) => {
+  const updated = [...props.modelValue]
+  const current = { ...updated[index] }
+
+  if (field === 'optionId') {
+    const opt = availableOptions.value.find(o => o.id === value)
+    current.optionId = value
+    current.optionName = opt ? opt.name : ''
+    current.valueId = ''
+    current.valueName = ''
+  } else if (field === 'valueId') {
+    const opt = availableOptions.value.find(o => o.id === current.optionId)
+    const val = opt?.values.find(v => v.id === value)
+    current.valueId = value
+    current.valueName = val ? val.value : ''
+  }
+
+  updated[index] = current
+  emit('update:modelValue', updated)
+}
+</script>
+
+<template>
+  <div class="options-section">
+    <h4>Options</h4>
+    <div v-if="loading">Loading options...</div>
+    <div v-else>
+      <div v-for="(option, index) in modelValue" :key="index" class="option-row">
+        <select
+          class="form-select"
+          v-model="option.optionId"
+          @change="updateOption(index, 'optionId', option.optionId)"
+        >
+          <option value="">Select option</option>
+          <option v-for="opt in availableOptions" :key="opt.id" :value="opt.id">
+            {{ opt.name }}
+          </option>
+        </select>
+        <select
+          class="form-select"
+          v-model="option.valueId"
+          @change="updateOption(index, 'valueId', option.valueId)"
+        >
+          <option value="">Select value</option>
+          <option
+            v-for="val in availableOptions.find(o => o.id === option.optionId)?.values || []"
+            :key="val.id"
+            :value="val.id"
+          >
+            {{ val.value }}
+          </option>
+        </select>
+        <button
+          v-if="modelValue.length > 1"
+          @click="removeOption(index)"
+          class="remove-option-btn"
+          type="button"
+        >
+          <IconTrash :size="16" />
+        </button>
+      </div>
+      <button @click="addOption" class="add-option-btn" type="button">
+        <IconPlus :size="14" />
+        <span>Add Option</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.option-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+.option-row select {
+  flex: 1;
+}
+.remove-option-btn {
+  background: none;
+  border: none;
+  color: #6b7280;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+}
+.add-option-btn {
+  margin-top: 0.5rem;
+  background: none;
+  border: 1px dashed #d1d5db;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+}
+</style>

--- a/admin/src/views/products/components/ProductCreateModal.vue
+++ b/admin/src/views/products/components/ProductCreateModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { IconX, IconUpload, IconPlus, IconTrash } from '@tabler/icons-vue'
+import OptionSelector from './OptionSelector.vue'
 
 const props = defineProps({
   isOpen: {
@@ -22,12 +23,14 @@ const productData = ref({
   categories: [],
   collections: [],
   variants: [
-    { 
-      title: 'Default', 
-      options: [{ name: '', value: '' }],
+    {
+      title: 'Default',
+      options: [
+        { optionId: '', optionName: '', valueId: '', valueName: '' }
+      ],
       sku: '',
       price: '',
-      inventory: '0' 
+      inventory: '0'
     }
   ]
 })
@@ -58,7 +61,9 @@ const setActiveTab = (tab: string) => {
 const addVariant = () => {
   productData.value.variants.push({
     title: `Variant ${productData.value.variants.length + 1}`,
-    options: [{ name: '', value: '' }],
+    options: [
+      { optionId: '', optionName: '', valueId: '', valueName: '' }
+    ],
     sku: '',
     price: '',
     inventory: '0'
@@ -67,14 +72,6 @@ const addVariant = () => {
 
 const removeVariant = (index: number) => {
   productData.value.variants.splice(index, 1)
-}
-
-const addOption = (variantIndex: number) => {
-  productData.value.variants[variantIndex].options.push({ name: '', value: '' })
-}
-
-const removeOption = (variantIndex: number, optionIndex: number) => {
-  productData.value.variants[variantIndex].options.splice(optionIndex, 1)
 }
 
 const handleSave = () => {
@@ -231,36 +228,7 @@ const handleClose = () => {
                 />
               </div>
               
-              <div class="options-section">
-                <h4>Options</h4>
-                <div v-for="(option, optionIndex) in variant.options" :key="optionIndex" class="option-row">
-                  <div class="option-inputs">
-                    <input 
-                      type="text" 
-                      v-model="option.name" 
-                      placeholder="Option name (e.g. Color)" 
-                      class="form-input"
-                    />
-                    <input 
-                      type="text" 
-                      v-model="option.value" 
-                      placeholder="Value (e.g. Red)" 
-                      class="form-input"
-                    />
-                  </div>
-                  <button 
-                    v-if="variant.options.length > 1" 
-                    @click="removeOption(variantIndex, optionIndex)" 
-                    class="remove-option-btn"
-                  >
-                    <IconTrash :size="16" />
-                  </button>
-                </div>
-                <button @click="addOption(variantIndex)" class="add-option-btn">
-                  <IconPlus :size="14" />
-                  <span>Add Option</span>
-                </button>
-              </div>
+              <OptionSelector v-model="variant.options" />
             </div>
             
             <button @click="addVariant" class="add-variant-btn">
@@ -522,33 +490,6 @@ label {
   margin: 0;
 }
 
-.options-section {
-  margin-top: 1rem;
-  padding-top: 1rem;
-  border-top: 1px solid #f3f4f6;
-}
-
-.options-section h4 {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #374151;
-  margin: 0 0 0.75rem;
-}
-
-.option-row {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.75rem;
-}
-
-.option-inputs {
-  display: flex;
-  gap: 0.75rem;
-  flex: 1;
-}
-
-.remove-option-btn,
 .remove-btn {
   background: none;
   border: none;
@@ -557,13 +498,9 @@ label {
   padding: 0.25rem;
   border-radius: 0.25rem;
 }
-
-.remove-option-btn:hover,
 .remove-btn:hover {
   background-color: #fee2e2;
 }
-
-.add-option-btn,
 .add-variant-btn {
   display: inline-flex;
   align-items: center;
@@ -578,7 +515,6 @@ label {
   cursor: pointer;
 }
 
-.add-option-btn:hover,
 .add-variant-btn:hover {
   background-color: #f3f4f6;
   color: #111827;


### PR DESCRIPTION
## Summary
- add option selector component to fetch and assign product options
- link variants to option IDs/values in create product modal
- send selected option references when creating products

## Testing
- `npm test`
- `npm --prefix admin test`


------
https://chatgpt.com/codex/tasks/task_e_68b46ad6d9ac8331bdfc40f94df9f736