### PR TITLE
feat: add modals and api for product options

### DIFF
--- a/admin/src/api/product-options.ts
+++ b/admin/src/api/product-options.ts
@@ -1,0 +1,35 @@
+import httpClient from './httpClient'
+
+export interface ProductOption {
+  id: string
+  name: string
+  displayName?: string
+  inputType: string
+  isRequired: boolean
+  position: number
+}
+
+export interface ProductOptionPayload {
+  name: string
+  displayName?: string
+  inputType: string
+  isRequired: boolean
+}
+
+export const listProductOptions = async (): Promise<ProductOption[]> => {
+  const data = await httpClient.get<{ options: ProductOption[] }>('/api/product-options')
+  return data.options ?? []
+}
+
+export const createProductOption = (payload: ProductOptionPayload) =>
+  httpClient.post<ProductOption>('/api/product-options', {
+    ...payload,
+    values: [],
+    productIds: []
+  })
+
+export const updateProductOption = (id: string, payload: Partial<ProductOptionPayload>) =>
+  httpClient.put<ProductOption>(`/api/product-options/${id}`, payload)
+
+export const deleteProductOption = (id: string) =>
+  httpClient.delete<void>(`/api/product-options/${id}`)

--- a/admin/src/views/products/components/ProductOptionCreateModal.vue
+++ b/admin/src/views/products/components/ProductOptionCreateModal.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { createProductOption, type ProductOptionPayload } from '../../../api/product-options'
+
+const props = defineProps<{ isOpen: boolean }>()
+const emit = defineEmits(['close', 'saved'])
+
+const form = ref<ProductOptionPayload>({
+  name: '',
+  displayName: '',
+  inputType: 'select',
+  isRequired: false
+})
+const error = ref('')
+
+const reset = () => {
+  form.value = { name: '', displayName: '', inputType: 'select', isRequired: false }
+  error.value = ''
+}
+
+const handleSave = async () => {
+  if (!form.value.name.trim()) {
+    error.value = 'Name is required'
+    return
+  }
+  try {
+    const option = await createProductOption({
+      ...form.value,
+      displayName: form.value.displayName || undefined
+    })
+    emit('saved', option)
+    reset()
+    emit('close')
+  } catch (e: any) {
+    error.value = e.message || 'Failed to create option'
+  }
+}
+
+const handleClose = () => {
+  reset()
+  emit('close')
+}
+</script>
+
+<template>
+  <div v-if="isOpen" class="modal-overlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h2>Create Product Option</h2>
+        <button class="close-btn" @click="handleClose">×</button>
+      </div>
+      <div class="modal-content">
+        <div v-if="error" class="error">{{ error }}</div>
+        <div class="form-group">
+          <label>Name</label>
+          <input v-model="form.name" type="text" class="form-input" />
+        </div>
+        <div class="form-group">
+          <label>Display Name</label>
+          <input v-model="form.displayName" type="text" class="form-input" />
+        </div>
+        <div class="form-group">
+          <label>Input Type</label>
+          <select v-model="form.inputType" class="form-input">
+            <option value="select">Select</option>
+            <option value="radio">Radio</option>
+            <option value="color">Color</option>
+            <option value="text">Text</option>
+          </select>
+        </div>
+        <div class="form-group checkbox">
+          <label>
+            <input type="checkbox" v-model="form.isRequired" />
+            Required
+          </label>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn" @click="handleSave">Save</button>
+        <button class="btn secondary" @click="handleClose">Cancel</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 400px;
+  max-width: 90%;
+  display: flex;
+  flex-direction: column;
+}
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+.modal-content {
+  flex: 1;
+}
+.form-group {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+.form-group.checkbox {
+  flex-direction: row;
+  align-items: center;
+}
+.form-input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.error {
+  color: red;
+  margin-bottom: 0.5rem;
+}
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+.btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  background-color: #3b82f6;
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.btn.secondary {
+  background-color: #6b7280;
+}
+</style>

--- a/admin/src/views/products/components/ProductOptionEditModal.vue
+++ b/admin/src/views/products/components/ProductOptionEditModal.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { updateProductOption, type ProductOption, type ProductOptionPayload } from '../../../api/product-options'
+
+const props = defineProps<{ isOpen: boolean; option: ProductOption | null }>()
+const emit = defineEmits(['close', 'saved'])
+
+const form = ref<ProductOptionPayload>({
+  name: '',
+  displayName: '',
+  inputType: 'select',
+  isRequired: false
+})
+const error = ref('')
+
+watch(() => props.option, (opt) => {
+  if (opt) {
+    form.value = {
+      name: opt.name,
+      displayName: opt.displayName || '',
+      inputType: opt.inputType,
+      isRequired: opt.isRequired
+    }
+    error.value = ''
+  }
+})
+
+const handleSave = async () => {
+  if (!props.option) return
+  if (!form.value.name.trim()) {
+    error.value = 'Name is required'
+    return
+  }
+  try {
+    const updated = await updateProductOption(props.option.id, {
+      ...form.value,
+      displayName: form.value.displayName || undefined
+    })
+    emit('saved', updated)
+    emit('close')
+  } catch (e: any) {
+    error.value = e.message || 'Failed to update option'
+  }
+}
+
+const handleClose = () => {
+  emit('close')
+}
+</script>
+
+<template>
+  <div v-if="isOpen" class="modal-overlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h2>Edit Product Option</h2>
+        <button class="close-btn" @click="handleClose">×</button>
+      </div>
+      <div class="modal-content">
+        <div v-if="error" class="error">{{ error }}</div>
+        <div class="form-group">
+          <label>Name</label>
+          <input v-model="form.name" type="text" class="form-input" />
+        </div>
+        <div class="form-group">
+          <label>Display Name</label>
+          <input v-model="form.displayName" type="text" class="form-input" />
+        </div>
+        <div class="form-group">
+          <label>Input Type</label>
+          <select v-model="form.inputType" class="form-input">
+            <option value="select">Select</option>
+            <option value="radio">Radio</option>
+            <option value="color">Color</option>
+            <option value="text">Text</option>
+          </select>
+        </div>
+        <div class="form-group checkbox">
+          <label>
+            <input type="checkbox" v-model="form.isRequired" />
+            Required
+          </label>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn" @click="handleSave">Save</button>
+        <button class="btn secondary" @click="handleClose">Cancel</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 400px;
+  max-width: 90%;
+  display: flex;
+  flex-direction: column;
+}
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+.modal-content {
+  flex: 1;
+}
+.form-group {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+.form-group.checkbox {
+  flex-direction: row;
+  align-items: center;
+}
+.form-input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.error {
+  color: red;
+  margin-bottom: 0.5rem;
+}
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+.btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  background-color: #3b82f6;
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.btn.secondary {
+  background-color: #6b7280;
+}
+</style>


### PR DESCRIPTION
## Summary
- replace prompt-based option management with modal dialogs
- centralize product option API interactions

## Testing
- `npm test`
- `npm --prefix admin test`


------
https://chatgpt.com/codex/tasks/task_e_68b46adc40e88331b7b208603fb549cf