### PR TITLE
Add customer creation form and API call

### DIFF
--- a/admin/src/api/customers.ts
+++ b/admin/src/api/customers.ts
@@ -9,6 +9,8 @@ export interface Customer {
   note?: string
 }
 
+export type CreateCustomerPayload = Omit<Customer, 'id'>
+
 export interface Order {
   id: string
   orderNumber: string
@@ -33,6 +35,10 @@ interface OrdersResponse {
 
 export function getCustomer(customerId: string) {
   return httpClient.get<Customer>(`/api/customers/${customerId}`)
+}
+
+export function createCustomer(data: CreateCustomerPayload) {
+  return httpClient.post<Customer, CreateCustomerPayload>('/api/customers', data)
 }
 
 export function updateCustomer(customerId: string, data: Partial<Customer>) {

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -95,6 +95,11 @@ const routes: RouteRecordRaw[] = [
     ]
   },
   {
+    path: '/customers/create',
+    name: 'CustomerCreate',
+    component: () => import('../views/customers/CustomerCreate.vue')
+  },
+  {
     path: '/customers/:id',
     name: 'CustomerDetail',
     component: () => import('../views/customers/CustomerDetail.vue')

--- a/admin/src/views/CustomersList.vue
+++ b/admin/src/views/CustomersList.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="customers-list">
     <h1>Customers</h1>
+    <div class="actions">
+      <RouterLink to="/customers/create">New Customer</RouterLink>
+    </div>
 
     <div v-if="loading" class="state">Loading...</div>
     <div v-else-if="error" class="state error">{{ error }}</div>
@@ -84,5 +87,9 @@ onMounted(() => {
 
 .state.error {
   color: red;
+}
+
+.actions {
+  margin-bottom: 10px;
 }
 </style>

--- a/admin/src/views/customers/CustomerCreate.vue
+++ b/admin/src/views/customers/CustomerCreate.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="customer-create">
+    <h1>Create Customer</h1>
+    <form @submit.prevent="handleSubmit">
+      <div>
+        <label>First Name</label>
+        <input v-model="form.firstName" />
+        <span v-if="errors.firstName" class="error">{{ errors.firstName }}</span>
+      </div>
+      <div>
+        <label>Last Name</label>
+        <input v-model="form.lastName" />
+        <span v-if="errors.lastName" class="error">{{ errors.lastName }}</span>
+      </div>
+      <div>
+        <label>Email</label>
+        <input v-model="form.email" type="email" />
+        <span v-if="errors.email" class="error">{{ errors.email }}</span>
+      </div>
+      <div>
+        <label>Phone</label>
+        <input v-model="form.phone" />
+      </div>
+      <div>
+        <label>Note</label>
+        <textarea v-model="form.note"></textarea>
+      </div>
+      <div v-if="errors.general" class="error">{{ errors.general }}</div>
+      <button type="submit" :disabled="isSubmitting">Create</button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { createCustomer, type CreateCustomerPayload, type Customer } from '../../api/customers'
+
+const router = useRouter()
+
+const form = reactive<CreateCustomerPayload>({
+  firstName: '',
+  lastName: '',
+  email: '',
+  phone: '',
+  note: ''
+})
+
+const errors = reactive<{ firstName?: string; lastName?: string; email?: string; general?: string }>({})
+const isSubmitting = ref(false)
+
+function validate() {
+  errors.firstName = form.firstName ? '' : 'First name is required'
+  errors.lastName = form.lastName ? '' : 'Last name is required'
+  if (!form.email) {
+    errors.email = 'Email is required'
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) {
+    errors.email = 'Invalid email'
+  } else {
+    errors.email = ''
+  }
+  return !errors.firstName && !errors.lastName && !errors.email
+}
+
+async function handleSubmit() {
+  errors.general = ''
+  if (!validate()) return
+  try {
+    isSubmitting.value = true
+    const customer: Customer = await createCustomer({
+      firstName: form.firstName,
+      lastName: form.lastName,
+      email: form.email,
+      phone: form.phone || undefined,
+      note: form.note || undefined
+    })
+    router.push(`/customers/${customer.id}`)
+  } catch (err: any) {
+    errors.general = err.message || 'Failed to create customer'
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>
+
+<style scoped>
+.error {
+  color: red;
+  display: block;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add createCustomer API call for POST /api/customers
- add customer creation form with validation and redirect
- link new "New Customer" button and route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46addcfa8833199c7d1ac1507f2c8