### PR TITLE
Improve customer detail validation

### DIFF
--- a/admin/src/api/httpClient.ts
+++ b/admin/src/api/httpClient.ts
@@ -27,7 +27,12 @@ async function request<T>(endpoint: string, config: RequestConfig = {}): Promise
     ...init
   })
   if (!response.ok) {
-    throw new Error(`HTTP error ${response.status}`)
+    let message = `HTTP error ${response.status}`
+    try {
+      const err = await response.json()
+      message = err.error || (Array.isArray(err.errors) ? err.errors.join(', ') : message)
+    } catch {}
+    throw new Error(message)
   }
   return await response.json() as T
 }

--- a/src/entities/Customer.ts
+++ b/src/entities/Customer.ts
@@ -7,7 +7,7 @@ import {
   BeforeInsert,
   BeforeUpdate,
 } from "typeorm";
-import { IsEmail, IsNotEmpty, IsOptional } from "class-validator";
+import { IsEmail, IsNotEmpty, IsOptional, Matches } from "class-validator";
 import bcrypt from "bcryptjs";
 import { v4 as uuidv4 } from "uuid";
 import { CustomerStatus } from "../enums/customer_status"; // Assuming CustomerStatus is defined in a separate file
@@ -31,6 +31,7 @@ export class Customer {
 
   @Column({ nullable: true })
   @IsOptional()
+  @Matches(/^\+?[1-9]\d{1,14}$/,{ message: "phone must be a valid phone number" })
   phone?: string;
 
   @Column({ nullable: true, select: false })

--- a/src/routes/customers.ts
+++ b/src/routes/customers.ts
@@ -69,7 +69,10 @@ router.post("/register", customerAuthRateLimit, async (req: Request, res: Respon
     // Validate
     const errors = await validate(customer);
     if (errors.length > 0) {
-      return res.status(400).json({ errors });
+      const errorMessages = errors.flatMap((err) =>
+        Object.values(err.constraints || {})
+      );
+      return res.status(400).json({ errors: errorMessages });
     }
 
     await customerRepository.save(customer);
@@ -532,7 +535,10 @@ router.post("/", async (req: Request, res: Response) => {
     // Validate
     const errors = await validate(customer);
     if (errors.length > 0) {
-      return res.status(400).json({ errors });
+      const errorMessages = errors.flatMap((err) =>
+        Object.values(err.constraints || {})
+      );
+      return res.status(400).json({ errors: errorMessages });
     }
 
     const savedCustomer = await customerRepository.save(customer);
@@ -563,7 +569,10 @@ router.put("/:id", async (req: Request, res: Response) => {
     // Validate
     const errors = await validate(customer);
     if (errors.length > 0) {
-      return res.status(400).json({ errors });
+      const errorMessages = errors.flatMap((err) =>
+        Object.values(err.constraints || {})
+      );
+      return res.status(400).json({ errors: errorMessages });
     }
 
     const updatedCustomer = await customerRepository.save(customer);


### PR DESCRIPTION
## Summary
- validate customer form fields with inline errors and disabled Save button
- include server validation errors for update customer
- validate phone number and parse API error responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46ade86108331819296045e238ff4