### PR TITLE
Ensure category relations default to empty arrays

### DIFF
--- a/src/entities/Category.ts
+++ b/src/entities/Category.ts
@@ -42,11 +42,11 @@ export class Category {
   @IsOptional()
   parentId?: string;
 
-  @Column("simple-array")
-  childrenIds: string[];
+  @Column("simple-array", { default: "" })
+  childrenIds: string[] = [];
 
-  @Column("simple-array")
-  productIds: string[];
+  @Column("simple-array", { default: "" })
+  productIds: string[] = [];
 
   @Column({ type: "simple-json", nullable: true })
   metadata?: Record<string, any>;

--- a/src/routes/categories.ts
+++ b/src/routes/categories.ts
@@ -119,8 +119,13 @@ router.get("/slug/:slug", async (req: Request, res: Response) => {
 router.post("/", async (req: Request, res: Response) => {
   try {
     const categoryRepository = AppDataSource.getRepository(Category);
-    
-    const category = categoryRepository.create(req.body);
+
+    const { childrenIds = [], productIds = [], ...rest } = req.body;
+    const category = categoryRepository.create({
+      ...rest,
+      childrenIds,
+      productIds,
+    });
     
     // Validate
     const errors = await validate(category);


### PR DESCRIPTION
## Summary
- initialize `Category` entity relationship arrays with defaults and persist empty arrays
- default category creation to empty `childrenIds` and `productIds`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46fe6e3c4833194295c9370180cb4