### PR TITLE
feat: add logging to category creation

### DIFF
--- a/src/routes/categories.ts
+++ b/src/routes/categories.ts
@@ -119,12 +119,15 @@ router.get("/slug/:slug", async (req: Request, res: Response) => {
 router.post("/", async (req: Request, res: Response) => {
   try {
     const categoryRepository = AppDataSource.getRepository(Category);
-    
+
+    logger.debug("Incoming category payload:", req.body);
+
     const category = categoryRepository.create(req.body);
-    
+
     // Validate
     const errors = await validate(category);
     if (errors.length > 0) {
+      logger.warn("Category validation failed:", errors);
       return res.status(400).json({ errors });
     }
 
@@ -148,6 +151,7 @@ router.post("/", async (req: Request, res: Response) => {
       }
     }
 
+    logger.info(`Category created with ID: ${savedCategory.id}`);
     res.status(201).json(savedCategory);
   } catch (error) {
     logger.error("Error creating category:", error);


### PR DESCRIPTION
## Summary
- log incoming category payload at debug level
- warn about validation errors before returning 400
- log successful category creation with new id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46feb680c8331bc125b1d48a67758