### PR TITLE
refactor: use httpClient for category creation

### DIFF
--- a/admin/src/views/products/CategoryCreate.vue
+++ b/admin/src/views/products/CategoryCreate.vue
@@ -78,6 +78,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
+import httpClient from '../../api/httpClient';
 
 const router = useRouter();
 
@@ -126,17 +127,7 @@ const createCategory = async () => {
 
   try {
     isSubmitting.value = true;
-    const res = await fetch('/api/categories', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    });
-
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}));
-      throw new Error(data.error || 'Failed to create category');
-    }
-
+    await httpClient.post('/api/categories', payload);
     router.push('/products/categories');
   } catch (err: any) {
     error.value = err.message || 'Failed to create category';


### PR DESCRIPTION
## Summary
- use shared httpClient for creating categories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46fe6edd88331bf9ef3274779bec6