### PR TITLE
feat(admin): add product options sidebar link

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -42,6 +42,7 @@ const routeDescriptions: Record<string, string> = {
   'Customers': 'Manage your customers',
   'Promotions': 'Create and manage promotions',
   'PriceLists': 'Manage your price lists',
+  'ProductOptions': 'Manage product options',
   'Analytics': 'View store analytics',
   'Settings': 'Configure your store settings'
 }
@@ -148,6 +149,9 @@ const getPageDescription = computed(() => {
               </router-link>
               <router-link to="/products/categories" class="sub-menu-item">
                 <span>Categories</span>
+              </router-link>
+              <router-link to="/product-options" class="sub-menu-item">
+                <span>Product Options</span>
               </router-link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add Product Options link under Products in admin sidebar
- include ProductOptions description for page header

## Testing
- `npm test`
- `cd admin && npm test`
- Verified `Product Options` sidebar link receives active class when navigating to `/product-options`


------
https://chatgpt.com/codex/tasks/task_e_68b46fb41bd88331b878a2de20906002