### PR TITLE
Validate product option input types and add toast notifications

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { 
-  IconPackage, 
-  IconSettings, 
+import {
+  IconPackage,
+  IconSettings,
   IconShoppingCart, 
   IconUsers, 
   IconSpeakerphone,
@@ -14,6 +14,7 @@ import {
 } from '@tabler/icons-vue'
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
+import Toast from 'primevue/toast'
 
 const route = useRoute()
 const expandedMenus = ref<string[]>(['products'])
@@ -56,6 +57,7 @@ const getPageDescription = computed(() => {
 </script>
 
 <template>
+  <Toast />
   <div class="app-container">
     <!-- Sidebar Navigation -->
     <aside class="sidebar">

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -4,6 +4,7 @@ import App from './App.vue'
 import router from './router'
 import PrimeVue from 'primevue/config'
 import Aura from '@primeuix/themes/lara'
+import ToastService from 'primevue/toastservice'
 import { setupAuthFetch } from './http'
 
 import 'primeicons/primeicons.css'
@@ -24,4 +25,5 @@ app.use(PrimeVue, {
         }
     }
  })
+app.use(ToastService)
 app.mount('#app')


### PR DESCRIPTION
## Summary
- add toast service and global Toast component
- validate product option input types and show API messages with toasts
- add debug logging for create/update product option dialogs

## Testing
- `npm test`
- `cd admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46fb5be548331abd50801a9c06203