### PR TITLE
feat: add toast notifications for product options

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { 
-  IconPackage, 
+import {
+  IconPackage,
   IconSettings, 
   IconShoppingCart, 
   IconUsers, 
@@ -14,6 +14,7 @@ import {
 } from '@tabler/icons-vue'
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
+import Toast from 'primevue/toast'
 
 const route = useRoute()
 const expandedMenus = ref<string[]>(['products'])
@@ -56,6 +57,7 @@ const getPageDescription = computed(() => {
 </script>
 
 <template>
+  <Toast />
   <div class="app-container">
     <!-- Sidebar Navigation -->
     <aside class="sidebar">

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -3,6 +3,7 @@ import './style.css'
 import App from './App.vue'
 import router from './router'
 import PrimeVue from 'primevue/config'
+import ToastService from 'primevue/toastservice'
 import Aura from '@primeuix/themes/lara'
 import { setupAuthFetch } from './http'
 
@@ -24,4 +25,5 @@ app.use(PrimeVue, {
         }
     }
  })
+app.use(ToastService)
 app.mount('#app')


### PR DESCRIPTION
## Summary
- add PrimeVue toast service
- display toast messages for product option fetch and delete operations
- block action buttons while requests are in flight

## Testing
- `npm test` (admin)
- `npm test` *(fails: ts-jest configuration warnings, no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68b46fb76ecc83319ca1ccd061f5f9b3