### PR TITLE
Enforce product option input type and payload validation

### DIFF
--- a/src/entities/ProductOption.ts
+++ b/src/entities/ProductOption.ts
@@ -6,7 +6,14 @@ import {
   UpdateDateColumn,
   BeforeInsert,
 } from "typeorm";
-import { IsNotEmpty, IsOptional, IsBoolean, IsNumber, Min } from "class-validator";
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsBoolean,
+  IsNumber,
+  Min,
+  IsEnum,
+} from "class-validator";
 import { v4 as uuidv4 } from "uuid";
 
 @Entity("product-options")
@@ -32,7 +39,8 @@ export class ProductOption {
   isRequired: boolean;
 
   @Column({ default: "select" })
-  inputType: string; // "select", "radio", "color", "text"
+  @IsEnum(["select", "radio", "color", "text"])
+  inputType: string; // Accepted values: "select", "radio", "color", "text"
 
   @Column({ type: "simple-json", nullable: true })
   values: Array<{


### PR DESCRIPTION
## Summary
- restrict `ProductOption.inputType` to select, radio, color or text
- validate product option payloads and surface detailed errors
- add debug/info logging for product option routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46fb8ac0c8331a7a86f71c3f2c1e1