### PR TITLE
Add Product Options link in admin sidebar

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -34,6 +34,7 @@ const isMenuExpanded = (menuKey: string) => {
 // Page descriptions based on route name
 const routeDescriptions: Record<string, string> = {
   'Products': 'Manage your inventory items',
+  'ProductOptions': 'Manage product options',
   'Inventory': 'Manage your inventory items',
   'Orders': 'Manage customer orders',
   'OrderClaims': 'Manage order claims',
@@ -148,6 +149,9 @@ const getPageDescription = computed(() => {
               </router-link>
               <router-link to="/products/categories" class="sub-menu-item">
                 <span>Categories</span>
+              </router-link>
+              <router-link to="/product-options" class="sub-menu-item">
+                <span>Product Options</span>
               </router-link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add "Product Options" link under Products menu
- document product options in route descriptions

## Testing
- `npm test` (in admin)
- `curl -I http://localhost:5175/product-options` (verify route availability)

------
https://chatgpt.com/codex/tasks/task_e_68b46ffdadbc8331b93d21f890bd9650