### PR TITLE
Enhance product option validation and logging

### DIFF
--- a/src/entities/ProductOption.ts
+++ b/src/entities/ProductOption.ts
@@ -6,7 +6,7 @@ import {
   UpdateDateColumn,
   BeforeInsert,
 } from "typeorm";
-import { IsNotEmpty, IsOptional, IsBoolean, IsNumber, Min } from "class-validator";
+import { IsNotEmpty, IsOptional, IsBoolean, IsNumber, Min, IsEnum } from "class-validator";
 import { v4 as uuidv4 } from "uuid";
 
 @Entity("product-options")
@@ -31,8 +31,12 @@ export class ProductOption {
   @IsBoolean()
   isRequired: boolean;
 
+  /**
+   * UI input type for the option. Allowed values: select, radio, color, text
+   */
   @Column({ default: "select" })
-  inputType: string; // "select", "radio", "color", "text"
+  @IsEnum(["select", "radio", "color", "text"])
+  inputType: string;
 
   @Column({ type: "simple-json", nullable: true })
   values: Array<{


### PR DESCRIPTION
## Summary
- enforce enum-based `inputType` for product options
- validate product option payloads and surface structured errors
- add debug/info logs for product option operations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b470004b2883319392af80bb82189e