### PR TITLE
feat: ensure unique category slug

### DIFF
--- a/src/entities/Category.ts
+++ b/src/entities/Category.ts
@@ -77,7 +77,9 @@ export class Category {
   @BeforeInsert()
   @BeforeUpdate()
   generateSlug() {
-    if (this.name) {
+    if (this.slug) {
+      this.slug = slugify(this.slug, { lower: true, strict: true });
+    } else if (this.name) {
       this.slug = slugify(this.name, { lower: true, strict: true });
     }
   }

--- a/src/routes/categories.ts
+++ b/src/routes/categories.ts
@@ -119,9 +119,19 @@ router.get("/slug/:slug", async (req: Request, res: Response) => {
 router.post("/", async (req: Request, res: Response) => {
   try {
     const categoryRepository = AppDataSource.getRepository(Category);
-    
+
     const category = categoryRepository.create(req.body);
-    
+    // Ensure slug is generated and unique
+    category.generateSlug();
+
+    const existing = await categoryRepository.findOne({
+      where: { slug: category.slug }
+    });
+
+    if (existing) {
+      return res.status(409).json({ error: req.t("errors.slug_already_exists") });
+    }
+
     // Validate
     const errors = await validate(category);
     if (errors.length > 0) {


### PR DESCRIPTION
## Summary
- allow Category entity to preserve provided slugs and fall back to slugifying the name
- prevent duplicate category slugs on creation and return a 409 when one already exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b470831c288331a7121bbf56f8383b