### PR TITLE
Expose category visibility in API

### DIFF
--- a/admin/src/api/categories.ts
+++ b/admin/src/api/categories.ts
@@ -5,8 +5,7 @@ export interface Category {
   name: string
   slug: string
   isActive: boolean
-  // Optionally there might be isVisible; include generics
-  isVisible?: boolean
+  visibility?: string
 }
 
 export async function getCategories() {

--- a/admin/src/views/products/CategoriesList.vue
+++ b/admin/src/views/products/CategoriesList.vue
@@ -96,7 +96,7 @@ const fetchCategories = async () => {
       name: c.name,
       handle: c.slug,
       status: c.isActive ? 'Active' : 'Inactive',
-      visibility: c.isVisible ? 'Public' : 'Private'
+      visibility: c.visibility || 'Public'
     }));
   } catch (error) {
     console.error('Failed to fetch categories:', error);

--- a/src/routes/categories.ts
+++ b/src/routes/categories.ts
@@ -57,7 +57,10 @@ router.get("/", async (req: Request, res: Response) => {
     ]);
 
     res.json({
-      categories: categories.map(c => translateCategory(c, locale)),
+      categories: categories.map(c => ({
+        ...translateCategory(c, locale),
+        visibility: c.metadata?.visibility ?? "Public",
+      })),
       pagination: {
         page: Number(page),
         limit: Number(limit),
@@ -86,7 +89,10 @@ router.get("/:id", async (req: Request, res: Response) => {
       return res.status(404).json({ error: req.t("errors.category_not_found") });
     }
 
-    res.json(translateCategory(category, locale));
+    res.json({
+      ...translateCategory(category, locale),
+      visibility: category.metadata?.visibility ?? "Public",
+    });
   } catch (error) {
     logger.error("Error fetching category:", error);
     res.status(500).json({ error: req.t("errors.failed_to_fetch_category") });
@@ -108,7 +114,10 @@ router.get("/slug/:slug", async (req: Request, res: Response) => {
       return res.status(404).json({ error: req.t("errors.category_not_found") });
     }
 
-    res.json(translateCategory(category, locale));
+    res.json({
+      ...translateCategory(category, locale),
+      visibility: category.metadata?.visibility ?? "Public",
+    });
   } catch (error) {
     logger.error("Error fetching category:", error);
     res.status(500).json({ error: req.t("errors.failed_to_fetch_category") });
@@ -148,7 +157,10 @@ router.post("/", async (req: Request, res: Response) => {
       }
     }
 
-    res.status(201).json(savedCategory);
+    res.status(201).json({
+      ...savedCategory,
+      visibility: savedCategory.metadata?.visibility ?? "Public",
+    });
   } catch (error) {
     logger.error("Error creating category:", error);
     res.status(500).json({ error: "Failed to create category" });
@@ -212,7 +224,10 @@ router.put("/:id", async (req: Request, res: Response) => {
       }
     }
 
-    res.json(updatedCategory);
+    res.json({
+      ...updatedCategory,
+      visibility: updatedCategory.metadata?.visibility ?? "Public",
+    });
   } catch (error) {
     logger.error("Error updating category:", error);
     res.status(500).json({ error: "Failed to update category" });
@@ -282,7 +297,12 @@ router.get("/:id/children", async (req: Request, res: Response) => {
       order: { sortOrder: "ASC" }
     });
 
-    res.json(children);
+    res.json(
+      children.map(c => ({
+        ...c,
+        visibility: c.metadata?.visibility ?? "Public",
+      }))
+    );
   } catch (error) {
     logger.error("Error fetching category children:", error);
     res.status(500).json({ error: "Failed to fetch category children" });


### PR DESCRIPTION
## Summary
- add `visibility` field to category API responses derived from `metadata.visibility`
- adjust admin categories list to use returned `visibility`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b470839bd88331b96105f1b7e2d063